### PR TITLE
Managed YTreeItem first item selection

### DIFF
--- a/package/libyui-ncurses.changes
+++ b/package/libyui-ncurses.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 14 10:30:15 CEST 2016 - anaselli@linux.it
+
+- Fix pre-selecting a tree item when adding it, in ncurses
+  (gh#libyui-ncurses/issues#26). The very first item would be 
+  selected, ignoring YTreeItem::setSelected
+
+-------------------------------------------------------------------
 Thu Jan 28 08:52:37 CET 2016 - gs@suse.de
 
 - replace deprecated auto_ptr by unique_ptr (bsc#962744)

--- a/src/NCTree.cc
+++ b/src/NCTree.cc
@@ -489,6 +489,29 @@ void NCTree::CreateTreeLines( NCTreeLine * parentLine, NCTreePad * pad, YItem * 
     NCTreeLine * line = new NCTreeLine( parentLine, treeItem, multiSel );
     pad->Append( line );
 
+    if (item->selected())
+    {
+        //retrieve position of item
+        int at = treeItem->index();
+        NCTreeLine * cline = 0;     // current line
+        NCTableCol * ccol = 0;      // current column
+        if ( multiSel )
+        {
+            cline = modifyTreeLine( at );
+            if ( cline )
+            {
+                ccol = cline->GetCol(0);
+            }
+            if ( ccol )
+            {
+                ccol->SetLabel( NCstring( std::string( cline->Level() + 3, ' ' ) + "[x] "
+                                      + item->label() ) );
+            }
+        }
+        //this highlights selected item, possibly unpacks the tree
+        //should it be in currently hidden branch
+        pad->ShowItem( getTreeLine( at ) );
+    }
     // iterate over children
 
     for ( YItemIterator it = item->childrenBegin();  it < item->childrenEnd(); ++it )


### PR DESCRIPTION
This PR fixes issue #26 and [the libyui one](https://github.com/libyui/libyui/issues/86)
To be fixed [**libyui PR**](https://github.com/libyui/libyui/pull/104) must be merged first
In a very first attempt i used in NCTree.cc the following code:
```
if (item->selected())
      selectItem( item, true );
```
but gaby said it had some bad side effects at that time, i think it was because of the missing libyui patch, but i haven't investigated more.
