### PR TITLE
This fixes mono detection so mono is used on vt220 as originally intended

### DIFF
--- a/src/NCstyle.cc
+++ b/src/NCstyle.cc
@@ -39,8 +39,8 @@
 #include "NCstyle.inverted.h"
 
 //initialize number of colors and color pairs
-int NCattribute::_colors = ::COLORS;
-int NCattribute::_pairs = ::COLOR_PAIRS;
+int NCattribute::_colors = 0;
+int NCattribute::_pairs = 0;
 
 
 

--- a/src/NCstyle.cc
+++ b/src/NCstyle.cc
@@ -44,6 +44,33 @@ int NCattribute::_pairs = ::COLOR_PAIRS;
 
 
 
+void NCattribute::init_colors()
+{
+
+    //get number of available colors (property of the terminal)
+    //the same with color pairs
+
+    _colors = ::COLORS;
+    _pairs = ::COLOR_PAIRS;
+
+    //if we have more than 8 colors available, use only 8 anyway
+    //in order to preserve the same color palette even for
+    //e.g. 256color terminal
+
+    if ( _colors > COLOR_WHITE + 1 )
+	//_colors = 8 at all times
+	_colors = COLOR_WHITE + 1;
+
+    if ( _pairs > _colors * _colors )
+	//_pairs == 64 at all times
+	_pairs = _colors * _colors;
+
+    for ( short i = 1; i < color_pairs(); ++i )
+	::init_pair( i, fg_color_pair( i ), bg_color_pair( i ) );
+}
+
+
+
 unsigned NCstyle::Style::sanitycheck()
 {
     return MaxSTglobal;

--- a/src/NCstyle.cc
+++ b/src/NCstyle.cc
@@ -47,6 +47,7 @@ int NCattribute::_pairs = ::COLOR_PAIRS;
 void NCattribute::init_colors()
 {
 
+    yuiMilestone() << "init_colors " << _colors << " -> " << ::COLORS << std::endl;
     //get number of available colors (property of the terminal)
     //the same with color pairs
 

--- a/src/NCstyle.h
+++ b/src/NCstyle.h
@@ -143,30 +143,7 @@ private:
 
     friend class NCurses;
 
-    static void init_colors()
-    {
-
-	//get number of available colors (property of the terminal)
-	//the same with color pairs
-
-	_colors = ::COLORS;
-	_pairs = ::COLOR_PAIRS;
-
-	//if we have more than 8 colors available, use only 8 anyway
-	//in order to preserve the same color palette even for
-	//e.g. 256color terminal
-
-	if ( _colors > COLOR_WHITE + 1 )
-	    //_colors = 8 at all times
-	    _colors = COLOR_WHITE + 1;
-
-	if ( _pairs > _colors * _colors )
-	    //_pairs == 64 at all times
-	    _pairs = _colors * _colors;
-
-	for ( short i = 1; i < color_pairs(); ++i )
-	    ::init_pair( i, fg_color_pair( i ), bg_color_pair( i ) );
-    }
+    static void init_colors();
 };
 
 

--- a/src/NCstyle.h
+++ b/src/NCstyle.h
@@ -45,7 +45,7 @@ struct NCattribute
     //if we have color support, return number of available colors
     //(at most 8 though)
     //will be initialized by init_color() function
-    inline static int colors()	    { return _colors ? _colors : ::COLORS; }
+    inline static int colors()	    { return _colors; }
 
     // do the same with color pairs
     inline static int color_pairs() { return _pairs ? _pairs : ::COLOR_PAIRS; }

--- a/src/NCurses.cc
+++ b/src/NCurses.cc
@@ -282,6 +282,7 @@ void NCurses::init()
     }
 
     yuiMilestone() << "have color = " << ::has_colors()  << std::endl;
+    yuiMilestone() << "want color = " << want_colors()   << std::endl;
 
     if ( want_colors() && ::has_colors() )
     {


### PR DESCRIPTION
There is a separate question why xterm and screen have different color theme from rxvt or why vt220 is supposed to be mono.

However, it the theme selection code says vt220 is supposed to be mono make it mono.

This results from investigation of ([bsc#1002985](https://bugzilla.suse.com/show_bug.cgi?id=1002985)).

This does not resolve the problem completely but fixes initialization problem which causes incorrect theme assignment.
