### PR TITLE
src: Replace using sys/errno.h with errno.h

### DIFF
--- a/src/NCAskForDirectory.cc
+++ b/src/NCAskForDirectory.cc
@@ -39,7 +39,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 /*
   Textdomain "ncurses"

--- a/src/NCAskForFile.cc
+++ b/src/NCAskForFile.cc
@@ -39,7 +39,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 /*
   Textdomain "ncurses"

--- a/src/NCFileSelection.h
+++ b/src/NCFileSelection.h
@@ -38,7 +38,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 
 struct NCFileInfo


### PR DESCRIPTION
sys/errno.h is no longer the right place for this file

error: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Werror=cpp]

Signed-off-by: Khem Raj <raj.khem@gmail.com>