### PR TITLE
use _nl_msg_cat_cntr only with glibc

### DIFF
--- a/src/NCi18n.h
+++ b/src/NCi18n.h
@@ -59,12 +59,13 @@ inline void setTextdomain( const char * domain )
     bindtextdomain( domain,  YSettings::localeDir().c_str() );
     bind_textdomain_codeset( domain, "UTF-8" );
     textdomain( domain );
-
+#if defined(__GLIBC__)
     // Make change known
     {
 	extern int _nl_msg_cat_cntr;
 	++_nl_msg_cat_cntr;
     }
+#endif
 }
 
 


### PR DESCRIPTION
The musl libc provides libintl (similar to glibc)
but does not use the same internals,
so even though we are using the GNU gettext
the libintl included with the libc does not define
_nl_msg_cat_cntr and it does not need to.

Signed-off-by: Khem Raj <raj.khem@gmail.com>