### PR TITLE
Custom Status Values for ItemSelector (NCurses part)

### DIFF
--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -37,6 +37,7 @@ SET( ${TARGETLIB}_SOURCES
   NCRadioButtonGroup.cc
   NCImage.cc
   NCItemSelector.cc
+  NCCustomStatusItemSelector.cc
   NCCheckBox.cc
   NCLabel.cc
   NCProgressBar.cc
@@ -112,6 +113,7 @@ SET( ${TARGETLIB}_HEADERS
   NCRadioButtonGroup.h
   NCImage.h
   NCItemSelector.h
+  NCCustomStatusItemSelector.h
   NCCheckBox.h
   NCLabel.h
   NCProgressBar.h

--- a/src/NCAlignment.h
+++ b/src/NCAlignment.h
@@ -35,7 +35,7 @@ class NCAlignment : public YAlignment, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCAlignment & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCAlignment & obj );
 
     NCAlignment & operator=( const NCAlignment & );
     NCAlignment( const NCAlignment & );

--- a/src/NCBusyIndicator.h
+++ b/src/NCBusyIndicator.h
@@ -42,7 +42,7 @@ class NCBusyIndicator : public YBusyIndicator, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCBusyIndicator & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCBusyIndicator & obj );
 
     NCBusyIndicator & operator=( const NCBusyIndicator & );
     NCBusyIndicator( const NCBusyIndicator & );

--- a/src/NCCheckBox.h
+++ b/src/NCCheckBox.h
@@ -34,7 +34,7 @@
 class NCCheckBox : public YCheckBox, public NCWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCCheckBox & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCCheckBox & obj );
 
     NCCheckBox & operator=( const NCCheckBox & );
     NCCheckBox( const NCCheckBox & );

--- a/src/NCCheckBoxFrame.h
+++ b/src/NCCheckBoxFrame.h
@@ -38,7 +38,7 @@ class NCCheckBoxFrame : public YCheckBoxFrame, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCCheckBoxFrame & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCCheckBoxFrame & obj );
 
     NCCheckBoxFrame & operator=( const NCCheckBoxFrame & );
     NCCheckBoxFrame( const NCCheckBoxFrame & );

--- a/src/NCComboBox.h
+++ b/src/NCComboBox.h
@@ -38,7 +38,7 @@ class NCComboBox : public YComboBox, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCComboBox & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCComboBox & obj );
 
     NCComboBox & operator=( const NCComboBox & );
     NCComboBox( const NCComboBox & );

--- a/src/NCCustomStatusItemSelector.cc
+++ b/src/NCCustomStatusItemSelector.cc
@@ -68,7 +68,7 @@ void NCCustomStatusItemSelector::updateCustomStatusIndicator( YItem * item )
     if ( ! item )
         return;
 
-    yuiMilestone() << "Updating status indicator for \"" << item->label() << "\"" << endl;
+    // yuiDebug() << "Updating status indicator for \"" << item->label() << "\"" << endl;
     NCCustomStatusTableTag * tag = (NCCustomStatusTableTag *) item->data();
     YUI_CHECK_PTR( tag );
 
@@ -86,10 +86,10 @@ void NCCustomStatusItemSelector::cycleCurrentItemStatus()
         int oldStatus = item->status();
         int newStatus = customStatus( oldStatus ).nextStatus();
 
-        yuiMilestone() << "Cycling status of item \""
-                       << item->label() << "\": "
-                       << oldStatus << " -> " << newStatus
-                       << endl;
+        yuiDebug() << "Cycling status of item \""
+                   << item->label() << "\": "
+                   << oldStatus << " -> " << newStatus
+                   << endl;
 
         if ( newStatus != -1 && oldStatus != newStatus )
         {
@@ -129,7 +129,6 @@ void NCCustomStatusTableTag::updateStatusIndicator()
     if ( item )
     {
         string statusText = _parentSelector->customStatus( item->status() ).textIndicator();
-yuiMilestone() << "New status text: \"" << statusText << "\"" << endl;
 
         // Since the parent class overwrote SetLabel() to do nothing,
         // we need to go one class up the class hierarchy to set the text.

--- a/src/NCCustomStatusItemSelector.cc
+++ b/src/NCCustomStatusItemSelector.cc
@@ -100,6 +100,18 @@ void NCCustomStatusItemSelector::cycleCurrentItemStatus()
 }
 
 
+bool NCCustomStatusItemSelector::statusChangeAllowed( int fromStatus, int toStatus )
+{
+    if ( fromStatus == toStatus ) // No use setting to the same status as before
+        return false;
+
+    if ( ! validCustomStatusIndex( fromStatus ) || ! validCustomStatusIndex( toStatus ) )
+        return false;
+
+    return customStatus( fromStatus ).nextStatus() == toStatus;
+}
+
+
 NCursesEvent
 NCCustomStatusItemSelector::valueChangedNotify( YItem * item )
 {

--- a/src/NCCustomStatusItemSelector.cc
+++ b/src/NCCustomStatusItemSelector.cc
@@ -1,0 +1,118 @@
+/*
+  Copyright (C) 2019 SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+   File:       NCCustomStatusItemSelector.cc
+
+   Author:     Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+
+#define	 YUILogComponent "ncurses"
+#include <yui/YUILog.h>
+#include "NCCustomStatusItemSelector.h"
+
+using std::string;
+
+
+NCCustomStatusItemSelector::NCCustomStatusItemSelector( YWidget * parent,
+                                                        const YItemCustomStatusVector & customStates )
+    : NCItemSelectorBase( parent, customStates )
+{
+    yuiDebug() << endl;
+}
+
+
+NCCustomStatusItemSelector::~NCCustomStatusItemSelector()
+{
+    yuiDebug() << endl;
+}
+
+
+NCTableTag * NCCustomStatusItemSelector::createTagCell( YItem * item )
+{
+    // FIXME: TO DO
+    // FIXME: TO DO
+    // FIXME: TO DO
+
+    NCTableTag * tag = new NCTableTag( item, item->selected(), enforceSingleSelection() );
+    YUI_CHECK_NEW( tag );
+
+    return tag;
+}
+
+
+NCTableTag * NCCustomStatusItemSelector::tagCell( int index ) const
+{
+    // FIXME: TO DO
+    // FIXME: TO DO
+    // FIXME: TO DO
+    
+    return NCItemSelectorBase::tagCell( index );
+}
+
+
+void NCCustomStatusItemSelector::cycleCurrentItemStatus()
+{
+    YItem *item = currentItem();
+
+    if ( item )
+    {
+        yuiMilestone() << "Cycling status of item " << item->label() << endl;
+    }
+}
+
+
+NCursesEvent NCCustomStatusItemSelector::wHandleInput( wint_t key )
+{
+    NCursesEvent ret;
+    bool valueChanged = false;
+
+    if ( ! handleInput( key ) )
+    {
+	YItem *curItem = currentItem();
+
+	switch ( key )
+	{
+	    case KEY_SPACE:
+	    case KEY_RETURN:
+
+                if ( ! curItem )
+                    curItem = scrollUpToPreviousItem();
+
+                if ( curItem )
+                {
+                    cycleCurrentItemStatus();
+                    valueChanged = true;
+                }
+                
+		break;
+	}
+    }
+
+    if ( notify() )
+    {
+        // FIXME TO DO: Send YMenuEvent
+        
+	if ( valueChanged )
+	    ret = NCursesEvent::ValueChanged;
+    }
+
+    return ret;
+}
+

--- a/src/NCCustomStatusItemSelector.cc
+++ b/src/NCCustomStatusItemSelector.cc
@@ -118,6 +118,8 @@ NCCustomStatusItemSelector::valueChangedNotify( YItem * item )
     NCursesEvent event( NCursesEvent::menu );
     event.selection = (YMenuItem *) item;
 
+    yuiDebug() << "Sending MenuEvent for item \"" << item->label() << "\"" << endl;
+
     return event;
 }
 

--- a/src/NCCustomStatusItemSelector.cc
+++ b/src/NCCustomStatusItemSelector.cc
@@ -100,40 +100,11 @@ void NCCustomStatusItemSelector::cycleCurrentItemStatus()
 }
 
 
-NCursesEvent NCCustomStatusItemSelector::wHandleInput( wint_t key )
+NCursesEvent
+NCCustomStatusItemSelector::valueChangedNotify( YItem * item )
 {
-    NCursesEvent event;
-    bool sendEvent = false;
-    YItem *curItem = currentItem();
-
-    if ( ! handleInput( key ) )
-    {
-	switch ( key )
-	{
-	    case KEY_SPACE:
-	    case KEY_RETURN:
-
-                if ( ! curItem )
-                    curItem = scrollUpToPreviousItem();
-
-                if ( curItem )
-                {
-                    cycleCurrentItemStatus();
-                    sendEvent = true;
-                }
-
-		break;
-	}
-    }
-
-    if ( notify() )
-    {
-	if ( sendEvent && curItem )
-        {
-	    event = NCursesEvent::menu;
-            event.selection = (YMenuItem *) curItem;
-        }
-    }
+    NCursesEvent event( NCursesEvent::menu );
+    event.selection = (YMenuItem *) item;
 
     return event;
 }

--- a/src/NCCustomStatusItemSelector.h
+++ b/src/NCCustomStatusItemSelector.h
@@ -31,6 +31,53 @@
 #include "NCItemSelector.h"
 
 
+/**
+ * Specialized subclass of NCTableTag that can not only handle a boolean
+ * "selected" flag (and accordingly set "[ ]" / "[x]" or "( )" / "(x)" as a
+ * status indicator), but extended numeric status values and an assciated text.
+ **/
+class NCCustomStatusTableTag: public NCTableTag // base class defined in NCTablePad.h
+{
+public:
+
+    NCCustomStatusTableTag( YItemSelector * parentSelector, YItem * item );
+    virtual ~NCCustomStatusTableTag() {}
+
+    virtual void DrawAt( NCursesWindow & w, const wrect at,
+			 NCTableStyle & tableStyle,
+			 NCTableLine::STATE linestate,
+			 unsigned colidx ) const;
+
+    virtual void SetSelected( bool sel );
+
+    virtual bool Selected() const;
+
+    virtual bool SingleSelection() const { return false; }
+
+    /**
+     * Return the numeric status value of the associated item.
+     **/
+    int status() const;
+
+    /**
+     * Set the numeric status value of the associated item and update the
+     * status indicator.
+     **/
+    void setStatus( int newStatus );
+
+    /**
+     * Update the status indicator according to the status of the associated
+     * item, i.e. display the status text for that custom status.
+     **/
+    void updateStatusIndicator();
+
+protected:
+
+    YItemSelector * _parentSelector;
+};
+
+
+
 class NCCustomStatusItemSelector : public NCItemSelectorBase
 {
     friend std::ostream & operator<<( std::ostream & str, const NCCustomStatusItemSelector & obj );
@@ -75,7 +122,15 @@ protected:
      * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
      * item with the specified index.
      **/
-    NCTableTag * tagCell( int index ) const;
+    virtual NCCustomStatusTableTag * tagCell( int index ) const;
+
+    /**
+     * Update the status indicator.
+     * This is only called if custom status values are used.
+     *
+     * Reimplemented from YItemSelector.
+     **/
+    virtual void updateCustomStatusIndicator( YItem * item );
 
 
 private:

--- a/src/NCCustomStatusItemSelector.h
+++ b/src/NCCustomStatusItemSelector.h
@@ -114,6 +114,12 @@ protected:
     virtual void cycleCurrentItemStatus();
 
     /**
+     * Return 'true' if a status change (by user interaction) from status
+     * 'fromStatus' to status 'toStatus' is allowed, 'false' if not.
+     **/
+    virtual bool statusChangeAllowed( int fromStatus, int toStatus );
+
+    /**
      * Notification that a status value was just changed in the input handler
      * and the 'notify' flag is set.
      **/

--- a/src/NCCustomStatusItemSelector.h
+++ b/src/NCCustomStatusItemSelector.h
@@ -1,0 +1,90 @@
+/*
+  Copyright (C) 2019 SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+   File:       NCCustomStatusItemSelector.h
+
+   Author:     Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+#ifndef NCCustomStatusItemSelector_h
+#define NCCustomStatusItemSelector_h
+
+#include <iosfwd>
+#include <string>
+
+#include "NCItemSelector.h"
+
+
+class NCCustomStatusItemSelector : public NCItemSelectorBase
+{
+    friend std::ostream & operator<<( std::ostream & str, const NCCustomStatusItemSelector & obj );
+
+public:
+
+    /**
+     * Constructor.
+     **/
+    NCCustomStatusItemSelector( YWidget * parent,
+                                const YItemCustomStatusVector & customStates );
+
+    /**
+     * Destructor.
+     **/
+    virtual ~NCCustomStatusItemSelector();
+
+    /**
+     * Handle keyboard input.
+     **/
+    virtual NCursesEvent wHandleInput( wint_t key );
+
+    virtual const char * location() const { return "NCCustomStatusItemSelector"; }
+
+
+protected:
+
+    /**
+     * Create a tag cell for an item. This is the cell with the "[x]" or "(x)"
+     * selector. It also stores the item pointer so the item can later be
+     * referenced by this tag.
+     **/
+    virtual NCTableTag * createTagCell( YItem * item );
+
+    /**
+     * Cycle the status of the current item through its possible values.
+     * For a plain ItemSelector, this means true -> false -> true.
+     **/
+    virtual void cycleCurrentItemStatus();
+
+    /**
+     * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
+     * item with the specified index.
+     **/
+    NCTableTag * tagCell( int index ) const;
+
+
+private:
+
+    // Disable assignement operator and copy constructor
+
+    NCCustomStatusItemSelector & operator=( const NCCustomStatusItemSelector & );
+    NCCustomStatusItemSelector( const NCCustomStatusItemSelector & );
+};
+
+
+#endif // NCCustomStatusItemSelector_h

--- a/src/NCCustomStatusItemSelector.h
+++ b/src/NCCustomStatusItemSelector.h
@@ -95,11 +95,6 @@ public:
      **/
     virtual ~NCCustomStatusItemSelector();
 
-    /**
-     * Handle keyboard input.
-     **/
-    virtual NCursesEvent wHandleInput( wint_t key );
-
     virtual const char * location() const { return "NCCustomStatusItemSelector"; }
 
 
@@ -117,6 +112,12 @@ protected:
      * For a plain ItemSelector, this means true -> false -> true.
      **/
     virtual void cycleCurrentItemStatus();
+
+    /**
+     * Notification that a status value was just changed in the input handler
+     * and the 'notify' flag is set.
+     **/
+    virtual NCursesEvent valueChangedNotify( YItem * item );
 
     /**
      * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the

--- a/src/NCDateField.h
+++ b/src/NCDateField.h
@@ -35,7 +35,7 @@
 class NCDateField : public YDateField, public NCInputTextBase
 {
 
-  friend std::ostream & operator<< ( std::ostream & STREAM, const NCDateField & OBJ );
+  friend std::ostream & operator<< ( std::ostream & str, const NCDateField & obj );
 
   NCDateField & operator= ( const NCDateField & );
   NCDateField ( const NCDateField & );

--- a/src/NCDialog.cc
+++ b/src/NCDialog.cc
@@ -1279,12 +1279,12 @@ NCursesEvent NCDialog::wHandleHotkey( wint_t key )
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCDialog * OBJ )
+std::ostream & operator<<( std::ostream & str, const NCDialog * obj )
 {
-    if ( OBJ )
-	return STREAM << *OBJ;
+    if ( obj )
+	return str << *obj;
 
-    return STREAM << "(NoNCDialog)";
+    return str << "(NoNCDialog)";
 }
 
 
@@ -1318,15 +1318,15 @@ std::map<int, NCstring> NCDialog::describeFunctionKeys( )
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCDialog & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCDialog & obj )
 {
-    STREAM << ( const NCWidget & )OBJ << ' ' << OBJ.pan
-    << ( OBJ.active ? "{A " : "{i " ) << OBJ.pendingEvent;
+    str << ( const NCWidget & )obj << ' ' << obj.pan
+    << ( obj.active ? "{A " : "{i " ) << obj.pendingEvent;
 
-    if ( OBJ.pendingEvent )
-	STREAM << OBJ.pendingEvent.widget;
+    if ( obj.pendingEvent )
+	str << obj.pendingEvent.widget;
 
-    return STREAM << '}';
+    return str << '}';
 }
 
 

--- a/src/NCDialog.h
+++ b/src/NCDialog.h
@@ -40,8 +40,8 @@ class NCDialog : public YDialog, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCDialog & OBJ );
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCDialog * OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCDialog & obj );
+    friend std::ostream & operator<<( std::ostream & str, const NCDialog * obj );
 
     NCDialog & operator=( const NCDialog & );
     NCDialog( const NCDialog & );

--- a/src/NCDumbTab.h
+++ b/src/NCDumbTab.h
@@ -35,7 +35,7 @@ class NCDumbTab : public YDumbTab, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCDumbTab & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCDumbTab & obj );
 
     NCDumbTab & operator=( const NCDumbTab & );
     NCDumbTab( const NCDumbTab & );

--- a/src/NCEmpty.h
+++ b/src/NCEmpty.h
@@ -35,7 +35,7 @@ class NCEmpty : public YEmpty, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCEmpty & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCEmpty & obj );
 
     NCEmpty & operator=( const NCEmpty & );
     NCEmpty( const NCEmpty & );

--- a/src/NCFrame.h
+++ b/src/NCFrame.h
@@ -37,7 +37,7 @@ class NCFrame : public YFrame, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCFrame & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCFrame & obj );
 
     NCFrame & operator=( const NCFrame & );
     NCFrame( const NCFrame & );

--- a/src/NCImage.h
+++ b/src/NCImage.h
@@ -37,7 +37,7 @@ class NCImage : public YImage, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCImage & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCImage & obj );
 
     NCImage & operator=( const NCImage & );
     NCImage( const NCImage & );

--- a/src/NCInputField.h
+++ b/src/NCInputField.h
@@ -34,7 +34,7 @@
 class NCInputField : public YInputField, public NCWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCInputField & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCInputField & obj );
 
     NCInputField & operator=( const NCInputField & );
     NCInputField( const NCInputField & );

--- a/src/NCInputTextBase.h
+++ b/src/NCInputTextBase.h
@@ -33,7 +33,7 @@
 class NCInputTextBase : public NCWidget
 {
 
-  friend std::ostream & operator<< ( std::ostream & STREAM, const NCInputTextBase & OBJ );
+  friend std::ostream & operator<< ( std::ostream & str, const NCInputTextBase & obj );
 
   NCInputTextBase & operator= ( const NCInputTextBase & );
   NCInputTextBase ( const NCInputTextBase & );

--- a/src/NCIntField.h
+++ b/src/NCIntField.h
@@ -35,7 +35,7 @@ class NCIntField : public YIntField, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCIntField & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCIntField & obj );
 
     NCIntField & operator=( const NCIntField & );
     NCIntField( const NCIntField & );

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -204,7 +204,7 @@ void NCItemSelectorBase::addItem( YItem * item )
             ++lineNo;
 	}
 
-	yuiDebug() << "Adding new item " << item->label() << " at line #" << lineNo << endl;
+	// yuiDebug() << "Adding new item " << item->label() << " at line #" << lineNo << endl;
 
 	// Add the item label with "[ ]" or "( )" for selection
 
@@ -326,6 +326,7 @@ NCItemSelectorBase::scrollDownToNextItem()
 	if ( item )
 	    return item;
 
+        // yuiDebug() << "Scrolling down" << endl;
 	myPad()->ScrlDown();
     }
 

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -442,8 +442,8 @@ NCItemSelectorBase::wHandleInput( wint_t key )
                     curItem = scrollUpToPreviousItem();
 
 		if ( curItem &&
-                     curItem->status() == 0 &&
-                     statusChangeAllowed( 0, 1 ) )
+                     curItem->status() != 1 &&
+                     statusChangeAllowed( curItem->status(), 1 ) )
                 {
                     setItemStatus( curItem, 1 );
                     changedItem = curItem;
@@ -464,8 +464,8 @@ NCItemSelectorBase::wHandleInput( wint_t key )
                     curItem = scrollUpToPreviousItem();
 
 		if ( curItem &&
-                     curItem->status() == 1 &&
-                     statusChangeAllowed( 1, 0 ) )
+                     curItem->status() > 0 &&
+                     statusChangeAllowed( curItem->status(), 0 ) )
                 {
                     setItemStatus( curItem, 0 );
                     changedItem = curItem;

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -388,6 +388,21 @@ NCItemSelectorBase::wHandleInput( wint_t key )
             scrollUpToPreviousItem();
             break;
 
+        // We would have liked to use KEY_SHIFT_UP and KEY_SHIFT_DOWN for
+        // scrolling up or down by line rather by item, but unfortunately
+        // NCurses does not support that at all; there are no predefined keys
+        // for any of that (but oddly enough KEY_SLEFT and KEY_SRIGHT for
+        // shifted arrow left or right), and there is no way to query the
+        // status of the modifier keys.
+        //
+        // See also /usr/include/ncurses/ncurses.h .
+        //
+        // There are lots of articles on StackOverflow etc. about this topic,
+        // but there is not a single portable solution; not even portable
+        // between the various terminal emulators (xterm, KDE konsole,
+        // gnome-terminal, xfce4-terminal) or the Linux console, let alone all
+        // the various other terminal types out there.
+
         default:
             handled = false;
             break;

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -406,6 +406,18 @@ NCItemSelectorBase::wHandleInput( wint_t key )
         // between the various terminal emulators (xterm, KDE konsole,
         // gnome-terminal, xfce4-terminal) or the Linux console, let alone all
         // the various other terminal types out there.
+        //
+        // So we have to resort to different keys. Not sure how many users will
+        // even realize that, but maybe some users actually try to use
+        // 'vi'-like keys like 'j' or 'k'.
+
+        case 'j':       // For 'vi' fans: Scroll down one line
+            myPad()->ScrlDown();
+            break;
+
+        case 'k':       // For 'vi' fans: Scroll up one line
+            myPad()->ScrlUp();
+            break;
 
         default:
             handled = false;

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -177,8 +177,10 @@ YItem * NCItemSelectorBase::currentItem() const
 
 void NCItemSelectorBase::setCurrentItem( YItem * item )
 {
-    if ( item )
-	myPad()->ScrlLine( item->index() );
+    int lineNo = findItemLine( item );
+
+    if ( lineNo >= 0 )
+	myPad()->ScrlLine( lineNo );
 }
 
 
@@ -215,6 +217,9 @@ void NCItemSelectorBase::addItem( YItem * item )
 	NCTableLine * tableLine = new NCTableLine( cells );
 	myPad()->Append( tableLine );
 
+        if ( enforceSingleSelection() && item->selected() )
+            myPad()->ScrlLine( lineNo );
+
 
 	// Add the item description (possible multi-line)
 
@@ -240,6 +245,20 @@ NCTableTag * NCItemSelectorBase::tagCell( int index ) const
 	return 0;
 
     return dynamic_cast<NCTableTag *> ( tableLine->GetCol( 0 ) );
+}
+
+
+int NCItemSelectorBase::findItemLine( YItem * wantedItem ) const
+{
+    for ( int lineNo = 0; lineNo < (int) myPad()->Lines(); ++lineNo )
+    {
+        NCTableTag * tag = tagCell( lineNo );
+
+        if ( tag && tag->origItem() == wantedItem )
+            return lineNo;
+    }
+
+    return -1;
 }
 
 

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -448,7 +448,7 @@ NCItemSelectorBase::wHandleInput( wint_t key )
 		break;
 
 
-	    case '+':   // select item or cycle item status and go to the next item
+	    case '+':   // select this item and go to the next item
 
                 if ( ! curItem )
                     curItem = scrollUpToPreviousItem();

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -281,13 +281,13 @@ void NCItemSelectorBase::deleteAllItems()
 }
 
 
-void NCItemSelectorBase::selectItem( YItem *yitem, bool selected )
+void NCItemSelectorBase::selectItem( YItem *item, bool selected )
 {
-    if ( yitem )
+    if ( item )
     {
-	YItemSelector::selectItem( yitem, selected );
+	YItemSelector::selectItem( item, selected );
 
-	NCTableTag * tag = (NCTableTag *) yitem->data();
+	NCTableTag * tag = (NCTableTag *) item->data();
 	YUI_CHECK_PTR( tag );
 
 	tag->SetSelected( selected );

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -339,16 +339,21 @@ NCItemSelectorBase::scrollDownToNextItem()
 YItem *
 NCItemSelectorBase::scrollUpToPreviousItem()
 {
-    while ( currentLine() >= 0 )
+    while ( true )
     {
 	YItem * item = currentItem();
 
 	if ( item )
 	    return item;
 
-	myPad()->ScrlUp();
+        if ( currentLine() == 0 )
+            return 0;
+
+        // yuiDebug() << "Scrolling up" << endl;
+        myPad()->ScrlUp();
     }
 
+    /**NOTREACHED**/
     return 0;
 }
 

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -42,7 +42,7 @@ NCItemSelectorBase::NCItemSelectorBase( YWidget * parent, bool enforceSingleSele
     , _prefSizeDirty( true )
     , _selectorWidth( string( "|[x] |" ).size() )
 {
-    yuiDebug() << endl;
+    // yuiDebug() << endl;
     InitPad();
 }
 
@@ -55,7 +55,7 @@ NCItemSelectorBase::NCItemSelectorBase( YWidget *			parent,
     , _prefSizeDirty( true )
     , _selectorWidth( 0 )
 {
-    yuiDebug() << endl;
+    // yuiDebug() << endl;
     InitPad();
 
     // Find the longest text indicator
@@ -74,7 +74,7 @@ NCItemSelectorBase::NCItemSelectorBase( YWidget *			parent,
 
 NCItemSelectorBase::~NCItemSelectorBase()
 {
-    yuiDebug() << endl;
+    // yuiDebug() << endl;
 }
 
 

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -437,10 +437,19 @@ NCItemSelectorBase::wHandleInput( wint_t key )
                 if ( ! curItem )
                     curItem = scrollUpToPreviousItem();
 
-		if ( curItem && ! curItem->selected() )
+		if ( curItem )
 		{
-		    selectItem( curItem, true );
                     changedItem = curItem;
+
+                    if ( usingCustomStatus() )
+                        cycleCurrentItemStatus();
+                    else
+                    {
+                        if ( ! curItem->selected() )
+                            selectItem( curItem, true );
+                        else
+                            changedItem = 0;
+                    }
 		}
 
 		myPad()->ScrlDown();
@@ -450,7 +459,7 @@ NCItemSelectorBase::wHandleInput( wint_t key )
 
 	    case '-':
 
-                if ( ! enforceSingleSelection() )
+                if ( ! enforceSingleSelection() && ! usingCustomStatus() )
                 {
                     if ( ! curItem )
                         curItem = scrollUpToPreviousItem();

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -235,6 +235,12 @@ protected:
     virtual NCTableTag * tagCell( int index ) const;
 
     /**
+     * Return the line number that contains the first line of 'item'
+     * or -1 if not found.
+     **/
+    int findItemLine( YItem * item ) const;
+
+    /**
      * Create the pad for this widget.
      **/
     virtual NCPad * CreatePad();

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -182,6 +182,13 @@ protected:
     virtual void cycleCurrentItemStatus() = 0;
 
     /**
+     * Return 'true' if a status change (by user interaction) from status
+     * 'fromStatus' to status 'toStatus' is allowed, 'false' if not.
+     **/
+    virtual bool statusChangeAllowed( int fromStatus, int toStatus )
+        { return false; }
+
+    /**
      * Notification that a status value was just changed in the input handler
      * and the 'notify' flag is set. The returned event is used as the return
      * value of the input handler (unless it has event type 'none' which is
@@ -297,6 +304,12 @@ protected:
      * For a plain ItemSelector, this means true -> false -> true.
      **/
     virtual void cycleCurrentItemStatus();
+
+    /**
+     * Return 'true' if a status change (by user interaction) from status
+     * 'fromStatus' to status 'toStatus' is allowed, 'false' if not.
+     **/
+    virtual bool statusChangeAllowed( int fromStatus, int toStatus );
 
     /**
      * Deselect all items except the specified one. This is used for single

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -72,7 +72,7 @@ public:
      * Return the current item, i.e. the item that currently has the keyboard
      * focus. Not to be confused with the selected item.
      **/
-    virtual YItem * currentItem();
+    virtual YItem * currentItem() const;
 
     /**
      * Set the current item, i.e. the item that currently has the keyboard
@@ -109,7 +109,13 @@ public:
      * label, optionally multiple lines for the description, and optionally a
      * separator line between it and the next item.
      **/
-    unsigned int getNumLines() { return myPad()->Lines(); }
+    int linesCount() const { return (int) myPad()->Lines(); }
+
+    /**
+     * Return number of the current line, i.e. the line that has the keyboard
+     * focus.
+     **/
+    int currentLine() const { return myPad()->CurPos().L; }
 
     /**
      * Add an item to this widget.
@@ -172,10 +178,24 @@ protected:
     bool isItemSelected( YItem *item );
 
     /**
-     * Toggle the status of the current item from 'true' to 'false' and the
-     * other way around.
+     * Cycle the status of the current item through its possible values.
+     * For a plain ItemSelector, this means true -> false -> true.
      **/
-    void toggleCurrentItem();
+    virtual void cycleCurrentItemStatus();
+
+    /**
+     * If the cursor is not on the first line of an item (the line with the
+     * "[x]" selector), scroll down to the next line that is the first line of
+     * an item.
+     **/
+    YItem * scrollDownToNextItem();
+
+    /**
+     * If the cursor is not on the first line of an item (the line with the
+     * "[x]" selector), scroll up to the next line that is the first line of
+     * an item.
+     **/
+    YItem * scrollUpToPreviousItem();
 
     /**
      * Return the preferred size for this widget.
@@ -183,21 +203,22 @@ protected:
     virtual wsze preferredSize();
 
     /**
+     * Create a tag cell for an item. This is the cell with the "[x]" or "(x)"
+     * selector. It also stores the item pointer so the item can later be
+     * referenced by this tag.
+     **/
+    virtual NCTableTag * createTagCell( YItem * item );
+
+    /**
+     * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
+     * item with the specified index.
+     **/
+    NCTableTag * tagCell( int index ) const;
+
+    /**
      * Create the pad for this widget.
      **/
     virtual NCPad * CreatePad();
-
-    /**
-     * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
-     * item with the specified index.
-     **/
-    NCTableTag * tagCell( int index );
-
-    /**
-     * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
-     * item with the specified index.
-     **/
-    const NCTableTag * tagCell( int index ) const;
 
     /**
      * Return the pad for this widget; overloaded to narrow the type.

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -216,7 +216,7 @@ protected:
      * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
      * item with the specified index.
      **/
-    NCTableTag * tagCell( int index ) const;
+    virtual NCTableTag * tagCell( int index ) const;
 
     /**
      * Create the pad for this widget.
@@ -274,7 +274,7 @@ public:
 
 
 protected:
-    
+
     /**
      * Create a tag cell for an item. This is the cell with the "[x]" or "(x)"
      * selector. It also stores the item pointer so the item can later be
@@ -294,7 +294,7 @@ protected:
      **/
     void deselectAllItemsExcept( YItem * exceptItem );
 
-    
+
 private:
 
     // Disable assignement operator and copy constructor

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -37,7 +37,7 @@
 class NCItemSelector : public YItemSelector, public NCPadWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCItemSelector & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCItemSelector & obj );
 
     NCItemSelector & operator=( const NCItemSelector & );
     NCItemSelector( const NCItemSelector & );

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -60,10 +60,8 @@ public:
 
     /**
      * Handle keyboard input.
-     *
-     * Derived classes are required to implement this.
      **/
-    virtual NCursesEvent wHandleInput( wint_t key ) = 0;
+    virtual NCursesEvent wHandleInput( wint_t key );
 
     /**
      * Return the preferred width for this widget.
@@ -184,6 +182,17 @@ protected:
     virtual void cycleCurrentItemStatus() = 0;
 
     /**
+     * Notification that a status value was just changed in the input handler
+     * and the 'notify' flag is set. The returned event is used as the return
+     * value of the input handler (unless it has event type 'none' which is
+     * also returned by the default constructor of NCursesEvent), i.e. it is
+     * sent to the application.
+     *
+     * Derived classes are required to implement this.
+     **/
+    virtual NCursesEvent valueChangedNotify( YItem * item ) = 0;
+
+    /**
      * Return the desription text for an item. The result may contain newlines.
      **/
     std::string description( YItem * item ) const;
@@ -265,11 +274,6 @@ public:
      **/
     virtual ~NCItemSelector();
 
-    /**
-     * Handle keyboard input.
-     **/
-    virtual NCursesEvent wHandleInput( wint_t key );
-
     virtual const char * location() const { return "NCItemSelector"; }
 
 
@@ -281,6 +285,12 @@ protected:
      * referenced by this tag.
      **/
     virtual NCTableTag * createTagCell( YItem * item );
+
+    /**
+     * Notification that a status value was just changed in the input handler
+     * and the 'notify' flag is set.
+     **/
+    virtual NCursesEvent valueChangedNotify( YItem * item );
 
     /**
      * Cycle the status of the current item through its possible values.

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -36,31 +36,110 @@
 
 class NCItemSelector : public YItemSelector, public NCPadWidget
 {
-
     friend std::ostream & operator<<( std::ostream & str, const NCItemSelector & obj );
 
-    NCItemSelector & operator=( const NCItemSelector & );
-    NCItemSelector( const NCItemSelector & );
-
-    wsze prefSize;
-    bool prefSizeDirty;
-
-protected:
+public:
 
     /**
-     * Overload myPad to narrow the type
-     */
-    virtual NCTablePad * myPad() const
-        { return dynamic_cast<NCTablePad*>( NCPadWidget::myPad() ); }
+     * Constructor.
+     **/
+    NCItemSelector( YWidget * parent, bool enforceSingleSelection );
 
-    NCTableTag * tagCell( int index );
-    const NCTableTag * tagCell( int index ) const;
+    /**
+     * Destructor.
+     **/
+    virtual ~NCItemSelector();
 
-    bool isItemSelected( YItem *item );
+    /**
+     * Return the preferred width for this widget.
+     * Reimplemented from YWidget.
+     **/
+    virtual int preferredWidth();
 
-    void toggleCurrentItem();
+    /**
+     * Return the preferred height for this widget.
+     * Reimplemented from YWidget.
+     **/
+    virtual int preferredHeight();
 
-public:
+    /**
+     * Set the size of this widget.
+     * Reimplemented from YWidget.
+     **/
+    virtual void setSize( int newWidth, int newHeight );
+
+    /**
+     * Return the current item, i.e. the item that currently has the keyboard
+     * focus. Not to be confused with the selected item.
+     **/
+    virtual YItem * currentItem();
+
+    /**
+     * Set the current item, i.e. the item that currently has the keyboard
+     * focus.
+     **/
+    virtual void setCurrentItem( YItem * item );
+
+    /**
+     * Handle keyboard input.
+     **/
+    virtual NCursesEvent wHandleInput( wint_t key );
+
+    /**
+     * Enable or disable this widget.
+     * Reimplemented from YWidget.
+     **/
+    virtual void setEnabled( bool do_bv );
+
+    /**
+     * Set the keyboard focus to this widget.
+     * Reimplemented from YWidget.
+     **/
+    virtual bool setKeyboardFocus();
+
+    /**
+     * Set the number of visible items for this widget.
+     * Reimplemented from YItemSelector.
+     **/
+    virtual void setVisibleItems( int newVal );
+
+    /**
+     * Return the number of lines in this widget. This is different from the
+     * number of items because each item always has one line for the item
+     * label, optionally multiple lines for the description, and optionally a
+     * separator line between it and the next item.
+     **/
+    unsigned int getNumLines() { return myPad()->Lines(); }
+
+    /**
+     * Add an item to this widget.
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void addItem( YItem * item );
+
+    /**
+     * Delete all items.
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void deleteAllItems();
+
+    /**
+     * Select or deselect an item.
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void selectItem( YItem * item, bool selected );
+
+    /**
+     * Deselect all items.
+     **/
+    virtual void deselectAllItems();
+
+    /**
+     * Return the text line with the specified line number. Notice that this is
+     * different from the item index (see getNumLines()).
+     **/
+    const NCTableLine * getLine( int lineNo ) { return myPad()->GetLine( lineNo ); }
+
 
     virtual void startMultipleChanges() { startMultidraw(); }
 
@@ -68,57 +147,82 @@ public:
 
     virtual const char * location() const { return "NCItemSelector"; }
 
-    virtual void addItem( YItem * item );
 
-    virtual void deleteAllItems();
+protected:
 
-    virtual void selectItem( YItem * item, bool selected );
+    /**
+     * Return the desription text for an item. The result may contain newlines.
+     **/
+    std::string description( YItem * item ) const;
 
-    virtual void deselectAllItems();
+    /**
+     * Return the description text for an item as multiple lines.
+     **/
+    std::vector<std::string> descriptionLines( YItem * item ) const;
+
+    /**
+     * Deselect all items except the specified one. This is used for single
+     * selection.
+     **/
+    void deselectAllItemsExcept( YItem * exceptItem );
+
+    /**
+     * Return 'true' if an item is selected, 'false' otherwise.
+     **/
+    bool isItemSelected( YItem *item );
+
+    /**
+     * Toggle the status of the current item from 'true' to 'false' and the
+     * other way around.
+     **/
+    void toggleCurrentItem();
+
+    /**
+     * Return the preferred size for this widget.
+     **/
+    virtual wsze preferredSize();
+
+    /**
+     * Create the pad for this widget.
+     **/
+    virtual NCPad * CreatePad();
+
+    /**
+     * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
+     * item with the specified index.
+     **/
+    NCTableTag * tagCell( int index );
+
+    /**
+     * Return the tag cell (the cell with the "[x]" or "(x)" selector) for the
+     * item with the specified index.
+     **/
+    const NCTableTag * tagCell( int index ) const;
+
+    /**
+     * Return the pad for this widget; overloaded to narrow the type.
+     */
+    virtual NCTablePad * myPad() const
+        { return dynamic_cast<NCTablePad*>( NCPadWidget::myPad() ); }
+
+    virtual void wRecoded() { NCPadWidget::wRecoded(); }
+
+
+private:
+
+    // Disable assignement operator and copy constructor
+
+    NCItemSelector & operator=( const NCItemSelector & );
+    NCItemSelector( const NCItemSelector & );
 
 
 protected:
 
-    virtual NCPad * CreatePad();
-    virtual void    wRecoded();
-    void deselectAllItemsExcept( YItem * exceptItem );
-    wsze preferredSize();
-    std::string description( YItem * item ) const;
-    std::vector<std::string> descriptionLines( YItem * item ) const;
+    // Data members
 
-
-public:
-
-    NCItemSelector( YWidget * parent, bool enforceSingleSelection );
-    virtual ~NCItemSelector();
-
-    virtual int preferredWidth();
-    virtual int preferredHeight();
-
-    virtual void setSize( int newWidth, int newHeight );
-
-    virtual YItem * currentItem();
-    virtual void setCurrentItem( YItem * item );
-
-    virtual NCursesEvent wHandleInput( wint_t key );
-
-    virtual void setEnabled( bool do_bv );
-
-    virtual bool setKeyboardFocus()
-    {
-        if ( ! grabFocus() )
-            return YWidget::setKeyboardFocus();
-
-        return true;
-    }
-
-    virtual void setVisibleItems( int newVal );
-
-    unsigned int getNumLines( ) { return myPad()->Lines(); }
-
-    const NCTableLine * getLine( int index ) { return myPad()->GetLine( index ); }
-
-    void clearItems() { return myPad()->ClearTable(); }
+    wsze _prefSize;
+    bool _prefSizeDirty;
+    int  _selectorWidth;
 };
 
 

--- a/src/NCLabel.h
+++ b/src/NCLabel.h
@@ -37,7 +37,7 @@ class NCLabel : public YLabel, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCLabel & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCLabel & obj );
 
     NCLabel & operator=( const NCLabel & );
     NCLabel( const NCLabel & );

--- a/src/NCLayoutBox.h
+++ b/src/NCLayoutBox.h
@@ -37,7 +37,7 @@ class NCLayoutBox : public YLayoutBox, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCLayoutBox & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCLayoutBox & obj );
 
     NCLayoutBox & operator=( const NCLayoutBox & );
     NCLayoutBox( const NCLayoutBox & );

--- a/src/NCLogView.h
+++ b/src/NCLogView.h
@@ -35,7 +35,7 @@ class NCLogView : public YLogView, public NCPadWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCLogView & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCLogView & obj );
 
     NCLogView & operator=( const NCLogView & );
     NCLogView( const NCLogView & );

--- a/src/NCMenuButton.h
+++ b/src/NCMenuButton.h
@@ -36,7 +36,7 @@ class NCMenuButton : public YMenuButton, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCMenuButton & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCMenuButton & obj );
 
     NCMenuButton & operator=( const NCMenuButton & );
     NCMenuButton( const NCMenuButton & );

--- a/src/NCMultiLineEdit.h
+++ b/src/NCMultiLineEdit.h
@@ -35,7 +35,7 @@
 class NCMultiLineEdit : public YMultiLineEdit, public NCPadWidget
 {
 private:
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCMultiLineEdit & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCMultiLineEdit & obj );
 
     NCMultiLineEdit & operator=( const NCMultiLineEdit & );
     NCMultiLineEdit( const NCMultiLineEdit & );

--- a/src/NCMultiSelectionBox.h
+++ b/src/NCMultiSelectionBox.h
@@ -39,7 +39,7 @@
 class NCMultiSelectionBox : public YMultiSelectionBox, public NCPadWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCMultiSelectionBox & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCMultiSelectionBox & obj );
 
     NCMultiSelectionBox & operator=( const NCMultiSelectionBox & );
     NCMultiSelectionBox( const NCMultiSelectionBox & );

--- a/src/NCPad.h
+++ b/src/NCPad.h
@@ -206,6 +206,11 @@ public:
 	return adjpos( wpos( 0, -cols ) );
     }
 
+    int ScrlToLastLine()
+    {
+        return ScrlDown( vheight() );
+    }
+
     virtual bool handleInput( wint_t key );
 };
 

--- a/src/NCPadWidget.h
+++ b/src/NCPadWidget.h
@@ -38,7 +38,7 @@ class NCPadWidget : public NCWidget, protected NCSchrollCB
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCPadWidget & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCPadWidget & obj );
 
     NCPadWidget & operator=( const NCPadWidget & );
     NCPadWidget( const NCPadWidget & );

--- a/src/NCProgressBar.h
+++ b/src/NCProgressBar.h
@@ -37,7 +37,7 @@ class NCProgressBar : public YProgressBar, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCProgressBar & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCProgressBar & obj );
 
     NCProgressBar & operator=( const NCProgressBar & );
     NCProgressBar( const NCProgressBar & );

--- a/src/NCPushButton.h
+++ b/src/NCPushButton.h
@@ -35,7 +35,7 @@ class NCPushButton : public YPushButton, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCPushButton & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCPushButton & obj );
 
     NCPushButton & operator=( const NCPushButton & );
     NCPushButton( const NCPushButton & );

--- a/src/NCRadioButton.h
+++ b/src/NCRadioButton.h
@@ -37,7 +37,7 @@ class NCRadioButton : public YRadioButton, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCRadioButton & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCRadioButton & obj );
 
     NCRadioButton & operator=( const NCRadioButton & );
     NCRadioButton( const NCRadioButton & );

--- a/src/NCRadioButtonGroup.h
+++ b/src/NCRadioButtonGroup.h
@@ -38,7 +38,7 @@ class NCRadioButtonGroup : public YRadioButtonGroup, public NCWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCRadioButtonGroup & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCRadioButtonGroup & obj );
 
     NCRadioButtonGroup & operator=( const NCRadioButtonGroup & );
     NCRadioButtonGroup( const NCRadioButtonGroup & );

--- a/src/NCReplacePoint.h
+++ b/src/NCReplacePoint.h
@@ -36,7 +36,7 @@ class NCReplacePoint;
 class NCReplacePoint : public YReplacePoint, public NCWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCReplacePoint & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCReplacePoint & obj );
 
     NCReplacePoint & operator=( const NCReplacePoint & );
     NCReplacePoint( const NCReplacePoint & );

--- a/src/NCRichText.h
+++ b/src/NCRichText.h
@@ -36,7 +36,7 @@ class NCRichText : public YRichText, public NCPadWidget
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCRichText & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCRichText & obj );
 
     NCRichText & operator=( const NCRichText & );
     NCRichText( const NCRichText & );

--- a/src/NCSelectionBox.h
+++ b/src/NCSelectionBox.h
@@ -35,7 +35,7 @@
 class NCSelectionBox : public YSelectionBox, public NCPadWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCSelectionBox & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCSelectionBox & obj );
 
     NCSelectionBox & operator=( const NCSelectionBox & );
     NCSelectionBox( const NCSelectionBox & );

--- a/src/NCSpacing.h
+++ b/src/NCSpacing.h
@@ -36,7 +36,7 @@
 class NCSpacing : public YSpacing, public NCWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCSpacing & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCSpacing & obj );
 
     NCSpacing & operator=( const NCSpacing & );
     NCSpacing( const NCSpacing & );

--- a/src/NCSquash.h
+++ b/src/NCSquash.h
@@ -34,7 +34,7 @@
 class NCSquash : public YSquash, public NCWidget
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCSquash & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCSquash & obj );
 
 private:
 

--- a/src/NCTable.h
+++ b/src/NCTable.h
@@ -127,7 +127,7 @@ private:
 
     std::vector<NCstring> _header;
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTable & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTable & obj );
 
     NCTable & operator=( const NCTable & );
     NCTable( const NCTable & );

--- a/src/NCTableItem.cc
+++ b/src/NCTableItem.cc
@@ -74,9 +74,9 @@ void NCTableCol::DrawAt( NCursesWindow & w, const wrect at,
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCTableCol & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCTableCol & obj )
 {
-    return STREAM << OBJ.label;
+    return str << obj.label;
 }
 
 
@@ -283,24 +283,24 @@ void NCTableLine::DrawItems( NCursesWindow & w, const wrect at,
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCTableLine & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCTableLine & obj )
 {
-    STREAM << "Line: cols " << OBJ.Cols() << std::endl;
+    str << "Line: cols " << obj.Cols() << std::endl;
 
-    for ( unsigned idx = 0; idx < OBJ.Cols(); ++idx )
+    for ( unsigned idx = 0; idx < obj.Cols(); ++idx )
     {
-	STREAM << "  " << idx << " ";
-	const NCTableCol * ci = OBJ.GetCol( idx );
+	str << "  " << idx << " ";
+	const NCTableCol * ci = obj.GetCol( idx );
 
 	if ( ci )
-	    STREAM << *ci;
+	    str << *ci;
 	else
-	    STREAM << "NO_ITEM";
+	    str << "NO_ITEM";
 
-	STREAM << std::endl;
+	str << std::endl;
     }
 
-    return STREAM;
+    return str;
 }
 
 
@@ -504,21 +504,21 @@ chtype NCTableStyle::getBG( const NCTableLine::STATE lstate,
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCTableStyle & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCTableStyle & obj )
 {
-    STREAM << form( "cols %d, sep %d (%lx)\n",
-		    OBJ.Cols(), OBJ.ColSepwidth(), (unsigned long)OBJ.ColSepchar() );
+    str << form( "cols %d, sep %d (%lx)\n",
+		    obj.Cols(), obj.ColSepwidth(), (unsigned long)obj.ColSepchar() );
 
-    for ( unsigned i = 0; i < OBJ.Cols(); ++i )
+    for ( unsigned i = 0; i < obj.Cols(); ++i )
     {
-	STREAM << form( "%2d %d(%3d) ", i, OBJ.ColAdjust( i ), OBJ.ColWidth( i ) );
+	str << form( "%2d %d(%3d) ", i, obj.ColAdjust( i ), obj.ColWidth( i ) );
 
-	if ( OBJ.Headline().GetCol( i ) )
-	    STREAM << OBJ.Headline().GetCol( i )->Label();
+	if ( obj.Headline().GetCol( i ) )
+	    str << obj.Headline().GetCol( i )->Label();
 
-	STREAM << std::endl;
+	str << std::endl;
     }
 
-    return STREAM;
+    return str;
 }
 

--- a/src/NCTableItem.h
+++ b/src/NCTableItem.h
@@ -39,7 +39,7 @@ class NCTableCol;
 class NCTableLine
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTableLine & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTableLine & obj );
 
     NCTableLine & operator=( const NCTableLine & );
     NCTableLine( const NCTableLine & );
@@ -146,7 +146,7 @@ public:
 class NCTableCol
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTableCol & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTableCol & obj );
 
 public:
 
@@ -222,7 +222,7 @@ public:
 class NCTableStyle
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTableStyle & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTableStyle & obj );
 
 private:
 

--- a/src/NCTablePad.cc
+++ b/src/NCTablePad.cc
@@ -260,8 +260,10 @@ int NCTablePad::setpos( const wpos & newpos )
 	return OK;
     }
 
+#if 0
     yuiDebug() << newpos << " : l " << Lines() << " : cl " << citem.L
                << " : d " << dirty << " : df " << dirtyFormat << std::endl;
+#endif
 
     if ( dirtyFormat )
 	UpdateFormat();

--- a/src/NCTablePad.cc
+++ b/src/NCTablePad.cc
@@ -177,7 +177,7 @@ wpos NCTablePad::CurPos() const
 
 wsze NCTablePad::UpdateFormat()
 {
-    yuiDebug() << std::endl;
+    // yuiDebug() << std::endl;
     dirty = true;
     dirtyFormat = false;
     ItemStyle.ResetToMinCols();
@@ -202,7 +202,7 @@ int NCTablePad::DoRedraw()
 	return OK;
     }
 
-    yuiDebug() << "dirtyFormat " << dirtyFormat << std::endl;
+    // yuiDebug() << "dirtyFormat " << dirtyFormat << std::endl;
 
     if ( dirtyFormat )
 	UpdateFormat();

--- a/src/NCTablePad.cc
+++ b/src/NCTablePad.cc
@@ -382,15 +382,15 @@ void NCTablePad::stripHotkeys()
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCTablePad & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCTablePad & obj )
 {
-    STREAM << "TablePad: lines " << OBJ.Lines() << std::endl;
+    str << "TablePad: lines " << obj.Lines() << std::endl;
 
-    for ( unsigned idx = 0; idx < OBJ.Lines(); ++idx )
+    for ( unsigned idx = 0; idx < obj.Lines(); ++idx )
     {
-	STREAM << idx << " " << *OBJ.GetLine( idx );
+	str << idx << " " << *obj.GetLine( idx );
     }
 
-    return STREAM;
+    return str;
 }
 

--- a/src/NCTablePad.h
+++ b/src/NCTablePad.h
@@ -166,7 +166,7 @@ public:
 class NCTablePad : public NCPad
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTablePad & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTablePad & obj );
 
     NCTablePad & operator=( const NCTablePad & );
     NCTablePad( const NCTablePad & );

--- a/src/NCTablePad.h
+++ b/src/NCTablePad.h
@@ -152,13 +152,13 @@ public:
 	}
     }
 
-    void SetSelected( bool sel ) { selected = sel; }
+    virtual void SetSelected( bool sel ) { selected = sel; }
 
-    bool Selected() const	       { return selected; }
+    virtual bool Selected() const       { return selected; }
 
-    bool SingleSelection() const       { return single_selection; }
+    virtual bool SingleSelection() const       { return single_selection; }
 
-    YItem *origItem() { return yitem; }
+    YItem *origItem() const { return yitem; }
 };
 
 

--- a/src/NCTablePad.h
+++ b/src/NCTablePad.h
@@ -130,7 +130,7 @@ public:
         , selected( sel )
         , single_selection( single_sel )
     {
-	//store pointer to this tag in Yitem data
+	// store pointer to this tag in Yitem data
 	yitem->setData( this );
     }
 

--- a/src/NCTextPad.cc
+++ b/src/NCTextPad.cc
@@ -587,11 +587,11 @@ std::wstring NCTextPad::getText() const
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCTextPad & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCTextPad & obj )
 {
-    STREAM << "at " << OBJ.CurPos() << " on " << wsze( OBJ.height(), OBJ.width() )
-    << " lines " << OBJ.lines.size() << " (" << *OBJ.cline << ")";
-    return STREAM;
+    str << "at " << obj.CurPos() << " on " << wsze( obj.height(), obj.width() )
+    << " lines " << obj.lines.size() << " (" << *obj.cline << ")";
+    return str;
 }
 
 void NCTextPad::setInputMaxLength( int nr )

--- a/src/NCTextPad.h
+++ b/src/NCTextPad.h
@@ -35,7 +35,7 @@
 class NCTextPad : public NCPad
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTextPad & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTextPad & obj );
 
     NCTextPad & operator=( const NCTextPad & );
     NCTextPad( const NCTextPad & );

--- a/src/NCTimeField.h
+++ b/src/NCTimeField.h
@@ -36,7 +36,7 @@
 class NCTimeField : public YTimeField, public NCInputTextBase
 {
 
-  friend std::ostream & operator<< ( std::ostream & STREAM, const NCTimeField & OBJ );
+  friend std::ostream & operator<< ( std::ostream & str, const NCTimeField & obj );
 
   NCTimeField & operator= ( const NCTimeField & );
   NCTimeField ( const NCTimeField & );

--- a/src/NCTree.h
+++ b/src/NCTree.h
@@ -38,7 +38,7 @@ class NCTreeLine;
 class NCTree : public YTree, public NCPadWidget
 {
 private:
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTree & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTree & obj );
 
     NCTree & operator=( const NCTree & );
     NCTree( const NCTree & );

--- a/src/NCTreePad.cc
+++ b/src/NCTreePad.cc
@@ -408,15 +408,15 @@ bool NCTreePad::handleInput( wint_t key )
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCTreePad & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCTreePad & obj )
 {
-    STREAM << "TreePad: lines " << OBJ.Lines() << std::endl;
+    str << "TreePad: lines " << obj.Lines() << std::endl;
 
-    for ( unsigned idx = 0; idx < OBJ.Lines(); ++idx )
+    for ( unsigned idx = 0; idx < obj.Lines(); ++idx )
     {
-	STREAM << idx << " " << *OBJ.GetLine( idx );
+	str << idx << " " << *obj.GetLine( idx );
     }
 
-    return STREAM;
+    return str;
 }
 

--- a/src/NCTreePad.h
+++ b/src/NCTreePad.h
@@ -40,7 +40,7 @@ class NCTreePad : public NCPad
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCTreePad & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCTreePad & obj );
 
     NCTreePad & operator=( const NCTreePad & );
     NCTreePad( const NCTreePad & );

--- a/src/NCWidget.cc
+++ b/src/NCWidget.cc
@@ -547,25 +547,25 @@ NCursesEvent NCWidget::wHandleInput( wint_t /*key*/ )
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCWidget * OBJ )
+std::ostream & operator<<( std::ostream & str, const NCWidget * obj )
 {
-    if ( OBJ && OBJ->isValid() )
-	return STREAM << *OBJ;
+    if ( obj && obj->isValid() )
+	return str << *obj;
 
-    return STREAM << "(NoNCWidget)";
+    return str << "(NoNCWidget)";
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCWidget & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCWidget & obj )
 {
-    if ( OBJ.isValid() )
-	return STREAM << OBJ.location() << ( void* )&OBJ
-	       << '(' << OBJ.win
-	       << ' ' << OBJ.inparent
-	       << ' ' << OBJ.wstate
+    if ( obj.isValid() )
+	return str << obj.location() << ( void* )&obj
+	       << '(' << obj.win
+	       << ' ' << obj.inparent
+	       << ' ' << obj.wstate
 	       << ')';
 
-    return STREAM << "( invalid NCWidget)";
+    return str << "( invalid NCWidget)";
 }
 
 

--- a/src/NCWidget.h
+++ b/src/NCWidget.h
@@ -46,8 +46,8 @@ class NCWidget : public tnode<NCWidget*>, protected NCursesError
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCWidget & OBJ );
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCWidget * OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCWidget & obj );
+    friend std::ostream & operator<<( std::ostream & str, const NCWidget * obj );
 
     NCWidget & operator=( const NCWidget & );
     NCWidget( const NCWidget & );

--- a/src/NCWidgetFactory.cc
+++ b/src/NCWidgetFactory.cc
@@ -265,6 +265,17 @@ NCWidgetFactory::createItemSelector( YWidget * parent, bool enforceSingleSelecti
 }
 
 
+NCCustomStatusItemSelector *
+NCWidgetFactory::createCustomStatusItemSelector( YWidget * parent, const YItemCustomStatusVector & customStates )
+{
+    NCCustomStatusItemSelector * itemSelector = new NCCustomStatusItemSelector( parent, customStates );
+    YUI_CHECK_NEW( itemSelector );
+
+    return itemSelector;
+}
+
+
+
 //
 // Layout Helpers
 //

--- a/src/NCWidgetFactory.h
+++ b/src/NCWidgetFactory.h
@@ -35,6 +35,7 @@
 #include "NCCheckBox.h"
 #include "NCCheckBoxFrame.h"
 #include "NCComboBox.h"
+#include "NCCustomStatusItemSelector.h"
 #include "NCDialog.h"
 #include "NCEmpty.h"
 #include "NCFrame.h"
@@ -116,7 +117,6 @@ public:
     virtual NCMultiSelectionBox*createMultiSelectionBox ( YWidget * parent, const std::string & label );
     virtual YPackageSelector *  createPackageSelector   ( YWidget * parent, long ModeFlags = 0 );
     virtual NCBusyIndicator *   createBusyIndicator     ( YWidget * parent, const std::string & label, int timeout = 1000 );
-    virtual NCItemSelector *    createItemSelector      ( YWidget * parent, bool enforceSingleSelection = true );
 
     // NCurses only
     virtual YWidget *           createPkgSpecial        ( YWidget * parent,  const std::string & subwidgetName );
@@ -146,6 +146,14 @@ public:
 
     virtual NCRadioButtonGroup *createRadioButtonGroup  ( YWidget * parent );
     virtual NCReplacePoint *    createReplacePoint      ( YWidget * parent );
+
+
+    //
+    // More leaf widgets (moved to the end to maintain ABI compatibility)
+    //
+
+    virtual NCItemSelector *             createItemSelector              ( YWidget * parent, bool enforceSingleSelection = true );
+    virtual NCCustomStatusItemSelector * createCustomStatusItemSelector  ( YWidget * parent, const YItemCustomStatusVector & customStates );
 
 
 protected:

--- a/src/NCstring.cc
+++ b/src/NCstring.cc
@@ -97,9 +97,9 @@ NCstring::NCstring( const char * cstr )
 
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCstring & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCstring & obj )
 {
-    return STREAM <<  OBJ.Str() ;
+    return str <<  obj.Str() ;
 }
 
 

--- a/src/NCstring.h
+++ b/src/NCstring.h
@@ -33,7 +33,7 @@ class NCstring
 {
 private:
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCstring & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCstring & obj );
 
 
     mutable wchar_t hotk;		// hotkey

--- a/src/NCtext.cc
+++ b/src/NCtext.cc
@@ -214,9 +214,9 @@ const NCstring & NCtext::operator[]( std::wstring::size_type idx ) const
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCtext & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCtext & obj )
 {
-    return STREAM << "[Text:" << OBJ.Lines() << ',' << OBJ.Columns() << ']';
+    return str << "[Text:" << obj.Lines() << ',' << obj.Columns() << ']';
 }
 
 
@@ -340,13 +340,13 @@ void NClabel::drawAt( NCursesWindow & w, chtype style, chtype hotstyle,
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NClabel & OBJ )
+std::ostream & operator<<( std::ostream & str, const NClabel & obj )
 {
-    STREAM << "[label" << OBJ.size() << ':' << OBJ[0].str();
+    str << "[label" << obj.size() << ':' << obj[0].str();
 
-    if ( OBJ.hasHotkey() )
-	STREAM << ':' << OBJ.hotkey() << " at " << OBJ.hotpos();
+    if ( obj.hasHotkey() )
+	str << ':' << obj.hotkey() << " at " << obj.hotpos();
 
-    return STREAM  << ']';
+    return str  << ']';
 }
 

--- a/src/NCtext.h
+++ b/src/NCtext.h
@@ -37,7 +37,7 @@ class NCursesWindow;
 class NCtext
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCtext & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCtext & obj );
 
 public:
 
@@ -81,7 +81,7 @@ public:
 class NClabel : protected NCtext
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NClabel & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NClabel & obj );
 
 protected:
 

--- a/src/NCurses.cc
+++ b/src/NCurses.cc
@@ -94,21 +94,21 @@ NCursesError & NCursesError::NCError( int val, const char * msg, ... )
 #undef CONVERR
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCursesError & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCursesError & obj )
 {
-    STREAM << form( "%s: (%d) %s"
-		    , OBJ.location()
-		    , OBJ.errval_i
-		    , OBJ.errmsg_t.c_str() );
-    return STREAM;
+    str << form( "%s: (%d) %s"
+		    , obj.location()
+		    , obj.errval_i
+		    , obj.errmsg_t.c_str() );
+    return str;
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCursesEvent & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCursesEvent & obj )
 {
-#define ENUM_OUT(v) case NCursesEvent::v: return STREAM << "Ev::" << #v
+#define ENUM_OUT(v) case NCursesEvent::v: return str << "Ev::" << #v
 
-    switch ( OBJ.type )
+    switch ( obj.type )
     {
 	ENUM_OUT( none );
 	ENUM_OUT( handled );
@@ -120,7 +120,7 @@ std::ostream & operator<<( std::ostream & STREAM, const NCursesEvent & OBJ )
     }
 
 #undef ENUM_OUT
-    return STREAM << "Ev::unknown";
+    return str << "Ev::unknown";
 }
 
 
@@ -719,38 +719,38 @@ void NCurses::ScreenShot( const std::string & name )
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const NCurses & OBJ )
+std::ostream & operator<<( std::ostream & str, const NCurses & obj )
 {
-    STREAM << form( "NC - %d x %d - colors %d - pairs %d\n"
-		    , OBJ.lines(), OBJ.cols()
+    str << form( "NC - %d x %d - colors %d - pairs %d\n"
+		    , obj.lines(), obj.cols()
 		    , NCattribute::colors(), NCattribute::color_pairs() );
 
     WINDOW * cw = ::stdscr;
-    STREAM << form( "NC - rootw %p", cw );
+    str << form( "NC - rootw %p", cw );
 
     if ( cw )
-	STREAM << form( " - (%2hd,%2hd)%2hdx%2hd - {%p - (%2d,%2d)}\n"
+	str << form( " - (%2hd,%2hd)%2hdx%2hd - {%p - (%2d,%2d)}\n"
 			, cw->_begy, cw->_begx
 			, cw->_maxy, cw->_maxx
 			, cw->_parent
 			, cw->_pary, cw->_parx
 		      );
     else
-	STREAM << std::endl;
+	str << std::endl;
 
-    cw = OBJ.title_w;
+    cw = obj.title_w;
 
-    STREAM << form( "NC - title %p", cw );
+    str << form( "NC - title %p", cw );
 
     if ( cw )
-	STREAM << form( " - (%2hd,%2hd)%2hdx%2hd - {%p - (%2d,%2d)}\n"
+	str << form( " - (%2hd,%2hd)%2hdx%2hd - {%p - (%2d,%2d)}\n"
 			, cw->_begy, cw->_begx
 			, cw->_maxy, cw->_maxx
 			, cw->_parent
 			, cw->_pary, cw->_parx
 		      );
     else
-	STREAM << std::endl;
+	str << std::endl;
 
-    return STREAM;
+    return str;
 }

--- a/src/NCurses.h
+++ b/src/NCurses.h
@@ -65,7 +65,7 @@ public:
     virtual const char * location() const { return "NCurses"; }
 };
 
-extern std::ostream & operator<<( std::ostream & STREAM, const NCursesError & OBJ );
+extern std::ostream & operator<<( std::ostream & str, const NCursesError & obj );
 
 
 
@@ -134,14 +134,14 @@ public:
     static const NCursesEvent ValueChanged;
 };
 
-extern std::ostream & operator<<( std::ostream & STREAM, const NCursesEvent & OBJ );
+extern std::ostream & operator<<( std::ostream & str, const NCursesEvent & obj );
 
 
 
 class NCurses
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const NCurses & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const NCurses & obj );
 
     NCurses & operator=( const NCurses & );
     NCurses( const NCurses & );

--- a/src/position.cc
+++ b/src/position.cc
@@ -26,24 +26,24 @@
 #include "position.h"
 
 
-std::ostream & operator<<( std::ostream & STREAM, const wpos & OBJ )
+std::ostream & operator<<( std::ostream & str, const wpos & obj )
 {
-    return STREAM << '(' << OBJ.L << ',' << OBJ.C << ')';
+    return str << '(' << obj.L << ',' << obj.C << ')';
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const wpair & OBJ )
+std::ostream & operator<<( std::ostream & str, const wpair & obj )
 {
-    return STREAM << '(' << OBJ.A << ',' << OBJ.B << ')';
+    return str << '(' << obj.A << ',' << obj.B << ')';
 }
 
 
-std::ostream & operator<<( std::ostream & STREAM, const wsze & OBJ )
+std::ostream & operator<<( std::ostream & str, const wsze & obj )
 {
-    return STREAM << '[' << OBJ.H << 'x' << OBJ.W << ']';
+    return str << '[' << obj.H << 'x' << obj.W << ']';
 }
 
-std::ostream & operator<<( std::ostream & STREAM, const wrect & OBJ )
+std::ostream & operator<<( std::ostream & str, const wrect & obj )
 {
-    return STREAM << '{' << OBJ.Pos << OBJ.Sze << '}';
+    return str << '{' << obj.Pos << obj.Sze << '}';
 }

--- a/src/position.h
+++ b/src/position.h
@@ -31,7 +31,7 @@
 class wpair
 {
 
-    friend std::ostream & operator<<( std::ostream & STREAM, const wpair & OBJ );
+    friend std::ostream & operator<<( std::ostream & str, const wpair & obj );
 
 protected:
 
@@ -145,7 +145,7 @@ public:
     wpos operator/( const wpair & Rhs ) const { return wpair::operator/( Rhs ); }
 };
 
-extern std::ostream & operator<<( std::ostream & STREAM, const wpos & OBJ );
+extern std::ostream & operator<<( std::ostream & str, const wpos & obj );
 
 
 
@@ -188,7 +188,7 @@ public:
     wsze operator/( const wpair & Rhs ) const { return wpair::operator/( Rhs ); }
 };
 
-extern std::ostream & operator<<( std::ostream & STREAM, const wsze & OBJ );
+extern std::ostream & operator<<( std::ostream & str, const wsze & obj );
 
 
 
@@ -274,7 +274,7 @@ public:
 
 };
 
-extern std::ostream & operator<<( std::ostream & STREAM, const wrect & OBJ );
+extern std::ostream & operator<<( std::ostream & str, const wrect & obj );
 
 
 #endif // wpair_h


### PR DESCRIPTION
## Trello

https://trello.com/c/dcDDFwGy/1405-5-allow-additional-status-values-in-multiitemselector

## Description

NCurses implementation for the CustomStatusItemSelector and greatly improved keyboard input handling for all variants of the ItemSelector.

## Screenshot

![NCCustomStatusItemSelector1](https://user-images.githubusercontent.com/11538225/68610524-4406a080-04b8-11ea-8122-d4f5e6a52b35.png)


## Details

### Input Handling

- The cursor keys scroll by items, not by lines.
- The `End` key scrolls to the last item, not to the last line.
- For scrolling by line there are vi-like key combinations: `j`, `k`.
- `PgDn` and `PgUp` scroll by a page full of lines.
- `Space` and `Return` cycle through the possible status values.
- `+` selects an item and moves to the next one.
- `-` deselects an item and moves to the next one.

- In custom status mode, both `+` and `-` check if that status transition is allowed according to the custom status definitions; i.e. if the custom status _nextStatus_ field of the current status (whatever that is right now) is `1` for `+` or `0` for `-`. 

  That makes it possible to still use `+` and `-` just like in a plain _ItemSelector_ if the status transitions `0 -> 1` and `1 -> 0` are defined; or even `n -> 0` for custom status #n. That way the `-` key can be made to work even with a custom status _install because it's recommended_ to move directly to `0` (_don't install_) if the custom status transitions are set up that way.

### Other Stuff

A _SingleItemSelector_ will automatically make the selected item (if there is one) the current item and scroll to that position.

That does _not_ affect the _MultiItemSelector_ or the _CustomStatusItemSelector_.