### PR TITLE
Auto-wrapping for YLabel Widgets (NCurses Part)

### DIFF
--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -61,6 +61,7 @@ SET( ${TARGETLIB}_SOURCES
   NCLogView.cc
   NCMultiLineEdit.cc
   NCFileSelection.cc
+  NCWordWrapper.cc
 
   NCPopup.cc
   NCPopupTable.cc
@@ -137,6 +138,7 @@ SET( ${TARGETLIB}_HEADERS
   NCLogView.h
   NCMultiLineEdit.h
   NCFileSelection.h
+  NCWordWrapper.h
   NCPopup.h
   NCPopupTable.h
   NCPopupList.h

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET( VERSION_MAJOR "2" )
-SET( VERSION_MINOR "54" )
-SET( VERSION_PATCH "5" )
+SET( VERSION_MINOR "55" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
-##### This is need for the libyui core, ONLY.
+##### This is needed for the libyui core ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "11" )
+SET( SONAME_MAJOR "12" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-ncurses-doc.spec
+++ b/package/libyui-ncurses-doc.spec
@@ -16,10 +16,10 @@
 #
 
 %define parent libyui-ncurses
-%define so_version 11
+%define so_version 12
 
 Name:           %{parent}-doc
-Version:        2.54.5
+Version:        2.55.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 
@@ -31,8 +31,8 @@ BuildRequires:  fdupes
 BuildRequires:  gcc-c++
 BuildRequires:  graphviz-gnome
 BuildRequires:  texlive-latex
-# YCustomStatusItemSelector
-BuildRequires:  libyui-devel >= 3.8.4
+# YLabel::setAutoWrap()
+BuildRequires:  libyui-devel >= 3.10.0
 
 Url:            http://github.com/libyui/
 Summary:        Libyui-ncurses documentation

--- a/package/libyui-ncurses.changes
+++ b/package/libyui-ncurses.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  4 12:05:43 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added autoWrap to label widget (bsc#1172513)
+- Bumped SO version to 12
+- 2.55.0
+
+-------------------------------------------------------------------
 Fri Jan 24 09:44:50 UTC 2020 - Michal Filka <mfilka@suse.com>
 
 - bsc#1154694

--- a/package/libyui-ncurses.spec
+++ b/package/libyui-ncurses.spec
@@ -17,11 +17,11 @@
 
 
 Name:           libyui-ncurses
-Version:        2.54.5
+Version:        2.55.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 11
+%define so_version 12
 %define bin_name %{name}%{so_version}
 
 %if 0%{?suse_version} > 1325
@@ -33,8 +33,8 @@ BuildRequires:  cmake >= 2.8
 BuildRequires:  gcc-c++
 BuildRequires:  pkg-config
 
-# YTableCell::sortKey
-%define libyui_devel_version libyui-devel >= 3.9.1
+# YLabel::setAutoWrap()
+%define libyui_devel_version libyui-devel >= 3.10.0
 BuildRequires:  %{libyui_devel_version}
 BuildRequires:  ncurses-devel
 

--- a/src/NCLabel.cc
+++ b/src/NCLabel.cc
@@ -27,9 +27,14 @@
 #include "NCurses.h"
 #include "NCLabel.h"
 
+#define AUTO_WRAP_WIDTH         10
+#define AUTO_WRAP_HEIGHT        1
+
+using std::string;
+
 
 NCLabel::NCLabel( YWidget *      parent,
-		  const std::string & nlabel,
+		  const string & nlabel,
 		  bool           isHeading,
 		  bool           isOutputField )
     : YLabel( parent, nlabel, isHeading, isOutputField )
@@ -51,13 +56,76 @@ NCLabel::~NCLabel()
 
 int NCLabel::preferredWidth()
 {
-    return wGetDefsze().W;
+    int width;
+
+    if ( autoWrap() )
+    {
+        if ( layoutPass() == 2 )
+        {
+            // Use the width passed down to us from the parent layout manager
+            // in the last setSize() call. This is the definitive width that
+            // will be used after taking all other children of the layout into
+            // consideration, also including making widgets smaller due to size
+            // restrictions, or redistributing excess space.
+            //
+            // Since this widget can auto-wrap its contents, we accept
+            // basically any width; we just need to adapt the preferred height
+            // accordingly.
+            width = wrapper.lineWidth();
+        }
+        else
+        {
+            // Use a preliminary width. Typically, this widget should be
+            // wrapped into a MinSize or MinWidth which hopefully gives us a
+            // much more useful width than this.
+            //
+            // We would also just use 0 here, but that would make debugging
+            // really hard since the widget might completly disappear.
+            //
+            // The real width that will be used will be set in the setSize()
+            // call following the recursive preferredWidth() /
+            // preferredHeight() calls in the widget tree.
+            width = AUTO_WRAP_WIDTH;
+        }
+    }
+    else  // ! autoWrap()
+    {
+        width = wGetDefsze().W;
+    }
+
+    return width;
 }
 
 
 int NCLabel::preferredHeight()
 {
-    return wGetDefsze().H;
+    int height;
+
+    if ( autoWrap() )
+    {
+        if ( layoutPass() == 2 )
+        {
+            // This is where the magic happens:
+            //
+            // setSize() in the first layout pass gave us the real width which
+            // we stored in as the wrapper's lineWidth. We can now let the
+            // wrapper wrap the text into that width and calculate the height
+            // (the number of lines of the wrapped text) that is really needed
+            // based on that width.
+            height = wrapper.lines();
+            label  = NCstring( wrapper.wrappedText() );
+        }
+        else
+        {
+            height = AUTO_WRAP_HEIGHT;
+        }
+    }
+    else  // ! autoWrap()
+    {
+        height = wGetDefsze().H;
+    }
+
+    return height;
 }
 
 
@@ -68,18 +136,20 @@ void NCLabel::setEnabled( bool do_bv )
 }
 
 
-void NCLabel::setSize( int newwidth, int newheight )
+void NCLabel::setSize( int newWidth, int newHeight )
 {
-    wRelocate( wpos( 0 ), wsze( newheight, newwidth ) );
+    if ( autoWrap() && layoutPass() == 1 )
+        wrapper.setLineWidth( newWidth );
+
+    wRelocate( wpos( 0 ), wsze( newHeight, newWidth ) );
 }
 
 
-void NCLabel::setText( const std::string & nlabel )
+void NCLabel::setText( const string & newLabel )
 {
-    label  = NCstring( nlabel );
-    yuiDebug() << "LABEL: " << NCstring( nlabel ) << " Longest line: " << label.width() << std::endl;
+    label = NCstring( newLabel );
     defsze = label.size();
-    YLabel::setText( nlabel );
+    YLabel::setText( newLabel );
     Redraw();
 }
 
@@ -94,5 +164,35 @@ void NCLabel::wRedraw()
 
     win->bkgd( bg );
     win->clear();
+
+    if ( autoWrap() )
+        label = NCstring( wrapper.wrappedText() );
+
     label.drawAt( *win, bg, bg );
 }
+
+
+void NCLabel::setAutoWrap( bool autoWrap )
+{
+    YLabel::setAutoWrap( autoWrap );
+
+    if ( autoWrap )
+    {
+        wrapper.setText( NCstring( text() ).str() );
+        // Delay setting 'label' until the line width for wrapping is set
+    }
+    else
+    {
+        // This will probably never happen since the default for autoWrap is
+        // 'false' and nobody will ever set an auto-wrapping label back to
+        // non-autowrapping programatically.
+        //
+        // But anyway, just in case: Let's revert the values to the initial
+        // defaults.
+
+        label = NCstring( text() );
+        defsze = label.size();
+        wrapper.clear();
+    }
+}
+

--- a/src/NCLabel.h
+++ b/src/NCLabel.h
@@ -29,6 +29,7 @@
 
 #include <yui/YLabel.h>
 #include "NCWidget.h"
+#include "NCWordWrapper.h"
 
 class NCLabel;
 
@@ -43,8 +44,9 @@ private:
     NCLabel( const NCLabel & );
 
 
-    bool    heading;
-    NClabel label;
+    bool          heading;
+    NClabel       label;
+    NCWordWrapper wrapper;
 
 protected:
 
@@ -69,6 +71,7 @@ public:
     virtual void setText( const std::string & nlabel );
 
     virtual void setEnabled( bool do_bv );
+    virtual void setAutoWrap( bool autoWrap = true );
 };
 
 

--- a/src/NCWordWrapper.cc
+++ b/src/NCWordWrapper.cc
@@ -1,0 +1,270 @@
+/*
+  Copyright (C) 2020 SUSE LLC
+
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+   File:       NCWordWrapper.h
+
+   Author:     Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+
+#include <cwctype>
+#include <iostream>
+#include "NCWordWrapper.h"
+
+
+#define DEFAULT_LINE_WIDTH      78
+
+using std::wstring;
+using std::endl;
+using std::wcout;
+
+
+NCWordWrapper::NCWordWrapper():
+    _lineWidth( DEFAULT_LINE_WIDTH ),
+    _lines( 0 ),
+    _dirty( false )
+{
+
+}
+
+
+void NCWordWrapper::setText( const wstring & origText )
+{
+    _origText = origText;
+    _dirty = true;
+}
+
+
+void NCWordWrapper::setLineWidth( int width )
+{
+    _lineWidth = width;
+    _dirty = true;
+}
+
+
+int NCWordWrapper::lines()
+{
+    ensureWrapped();
+
+    return _lines;
+}
+
+
+const wstring & NCWordWrapper::wrappedText()
+{
+    ensureWrapped();
+
+    return _wrappedText;
+}
+
+
+void NCWordWrapper::ensureWrapped()
+{
+    if ( _dirty )
+        wrap();
+
+    _dirty = false;
+}
+
+
+wstring NCWordWrapper::normalizeWhitespace( const wstring & orig )
+{
+    wstring normalized;
+    normalized.reserve( orig.size() );
+    bool skippingWhitespace = false;
+
+    for ( wchar_t c: orig )
+    {
+        switch ( c )
+        {
+	    case L' ':  // Whitespace
+	    case L'\t':
+	    case L'\n':
+	    case L'\v':
+	    case L'\r':
+            case L'\f':
+                // Don't add any whitespace right now: Wait until there is real content.
+
+                if ( ! normalized.empty() ) // Ignore any leading whitspace
+                    skippingWhitespace = true;
+                break;
+
+            default:    // Non-whitespace
+
+                // Add one blank for any skipped whitespace.
+                //
+                // This will not add trailing whitespace which is exactly the
+                // desired behaviour.
+
+                if ( skippingWhitespace )
+                    normalized += ' ';
+
+                normalized += c;
+                skippingWhitespace = false;
+                break;
+        }
+    }
+
+    return normalized;
+}
+
+
+void NCWordWrapper::wrap()
+{
+    wstring unwrapped = normalizeWhitespace( _origText );
+    _wrappedText.clear();
+    _wrappedText.reserve( unwrapped.size() );
+    _lines = 0;
+
+    while ( ! unwrapped.empty() )
+    {
+        wstring line = nextLine( unwrapped );
+
+#ifdef WORD_WRAPPER_TESTER
+        wcout << "Line: \"" << line << "\"  length: " << line.size() << endl;
+        wcout << "Rest: \"" << unwrapped << "\"\n" << endl;
+#endif
+
+        if ( ! _wrappedText.empty() )
+            _wrappedText += L'\n';
+
+        _wrappedText += line;
+        _lines++;
+    }
+
+    _dirty = false;
+}
+
+
+wstring NCWordWrapper::nextLine( wstring & unwrapped )
+{
+    wstring line;
+
+#ifdef WORD_WRAPPER_TESTER
+    wcout << "nextLine( \"" << unwrapped << "\" )" << endl;
+#endif
+
+    if ( (int) unwrapped.size() <= _lineWidth )
+    {
+        // The remaining unwrapped text fits into one line
+
+        line = unwrapped;
+        unwrapped.clear();
+
+        return line;
+    }
+
+
+    // Try to wrap at the rightmost possible whitespace
+
+    int pos = _lineWidth; // The whitespace will be removed here
+
+    while ( pos > 0 && unwrapped[ pos ] != L' ' )
+        --pos;
+
+    if ( unwrapped[ pos ] == L' ' )
+    {
+        line = unwrapped.substr( 0, pos );
+        unwrapped.erase( 0, pos + 1 );
+
+        return line;
+    }
+
+
+    // Try to wrap at the rightmost possible non-alphanum character
+
+    pos = _lineWidth - 1; // We'll need to keep the separator character
+
+    while ( pos > 0 && iswalnum( unwrapped[ pos ] ) )
+        --pos;
+
+    if ( ! iswalnum( unwrapped[ pos ] ) )
+    {
+#ifdef WORD_WRAPPER_TESTER
+        wcout << "iswalnum wrap" << endl;
+#endif
+
+        line = unwrapped.substr( 0, pos + 1 );
+        unwrapped.erase( 0, pos + 1 );
+
+        return line;
+    }
+
+
+    // Still no chance to break the line? So we'll have to break in mid-word.
+    // This is crude and brutal, but in some locales (Chinese, Japanese,
+    // Korean) there is very little whitespace, so sometimes we have no other
+    // choice.
+
+#ifdef WORD_WRAPPER_TESTER
+    wcout << "desperation wrap" << endl;
+#endif
+
+    pos = _lineWidth - 1;
+    line = unwrapped.substr( 0, pos + 1 );
+    unwrapped.erase( 0, pos + 1 );
+
+    return line;
+}
+
+
+// ----------------------------------------------------------------------
+
+
+// Standalone test frame for this class.
+//
+// Build with
+//
+//     g++ -D WORD_WRAPPER_TESTER -o word-wrapper-tester NCWordWrapper.cc
+//
+// Usage:
+//
+//    ./word-wrapper-tester "text to wrap" <line-length>
+
+#ifdef WORD_WRAPPER_TESTER
+
+
+int main( int argc, char *argv[] )
+{
+    NCWordWrapper wrapper;
+
+    if ( argc != 3 )
+    {
+        std::cerr << "\nUsage: " << argv[0] << " \"text to wrap\" <line-length>\n" << endl;
+        exit( 1 );
+    }
+
+    std::string src( argv[1] );
+    wstring input( src.begin(), src.end() );
+    int lineWidth = atoi( argv[2] );
+
+    wcout << "Wrapping to " << lineWidth << " columns:\n\"" << input << "\"\n" << endl;
+
+    wrapper.setText( input );
+    wrapper.setLineWidth( lineWidth );
+    wrapper.wrap();
+
+    wcout << "         10        20        30        40        50" << endl;
+    wcout << "12345678901234567890123456789012345678901234567890"  << endl;
+    wcout << wrapper.wrappedText() << endl;
+    wcout << "-- Wrapped lines: " << wrapper.lines() << endl;
+}
+
+#endif

--- a/src/NCWordWrapper.cc
+++ b/src/NCWordWrapper.cc
@@ -47,15 +47,31 @@ NCWordWrapper::NCWordWrapper():
 
 void NCWordWrapper::setText( const wstring & origText )
 {
-    _origText = origText;
-    _dirty = true;
+    if ( origText != _origText )
+    {
+        _origText = origText;
+        _dirty = true;
+    }
 }
 
 
 void NCWordWrapper::setLineWidth( int width )
 {
-    _lineWidth = width;
-    _dirty = true;
+    if ( width != _lineWidth )
+    {
+        _lineWidth = width;
+        _dirty = true;
+    }
+}
+
+
+void NCWordWrapper::clear()
+{
+    _origText.clear();
+    _wrappedText.clear();
+    _lineWidth = DEFAULT_LINE_WIDTH;
+    _lines = 0;
+    _dirty = false;
 }
 
 

--- a/src/NCWordWrapper.cc
+++ b/src/NCWordWrapper.cc
@@ -253,6 +253,13 @@ wstring NCWordWrapper::nextLine( wstring & unwrapped )
 // Usage:
 //
 //    ./word-wrapper-tester "text to wrap" <line-length>
+//
+// Notice that this does not do any fancy UTF-8 recoding of the command line
+// arguments, so non-ASCII characters may be slightly broken. This is expected,
+// and for the sake of simplicity, this will not be fixed. This only affects
+// this test frame; the tested class can handle UTF-8 characters just fine
+// (thus "Lörem üpsum" instead of "Lorem ipsum" in the AutoWrap*.cc libyui
+// examples).
 
 #ifdef WORD_WRAPPER_TESTER
 

--- a/src/NCWordWrapper.h
+++ b/src/NCWordWrapper.h
@@ -82,8 +82,19 @@ public:
 
     /**
      * Do the wrapping.
+     *
+     * This normally doesn't need to be called manually; it is done
+     * automatically when retrieving the wrapped text or the number of wrapped
+     * lines (and when the internal 'dirty' flag is set).
+     *
+     * But it can be useful to call it manually for debugging and testing.
      **/
     void wrap();
+
+    /**
+     * Clear the old content.
+     **/
+    void clear();
 
 
 protected:
@@ -98,7 +109,7 @@ protected:
      * 'unwrapped'.
      **/
     std::wstring nextLine( std::wstring & unwrapped );
-    
+
     //
     // Data members
     //

--- a/src/NCWordWrapper.h
+++ b/src/NCWordWrapper.h
@@ -1,0 +1,113 @@
+/*
+  Copyright (C) 2020 SUSE LLC
+
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+   File:       NCWordWrapper.h
+
+   Author:     Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+
+#ifndef NCWordWrapper_h
+#define NCWordWrapper_h
+
+#include <string>
+
+/**
+ * Helper class to word-wrap text into a specified maximum line width.
+ * Whitespace is normalized in the process, i.e. any sequence of whitespace
+ * (blanks, newlines, tabs, ...) is replaced by a single blank. All lines end
+ * with a single newline character except the last one which has no newline.
+ **/
+class NCWordWrapper
+{
+public:
+
+    /**
+     * Constructor.
+     **/
+    NCWordWrapper();
+
+    /**
+     * Set the original text to wrap.
+     **/
+    void setText( const std::wstring & origText );
+
+    /**
+     * Set the maximum line width to wrap into.
+     **/
+    void setLineWidth( int width );
+
+    /**
+     * Return the number of lines after wrapping the original text.
+     **/
+    int lines();
+
+    /**
+     * Wrap the original text and return the wrapped text.
+     **/
+    const std::wstring & wrappedText();
+
+    /**
+     * Return the original unwrapped text.
+     **/
+    const std::wstring & origText() const { return _origText; }
+
+    /**
+     * Return the last used maximum line width.
+     **/
+    int lineWidth() const { return _lineWidth; }
+
+    /**
+     * Return a string where any sequence of whitespace in the original text is
+     * replaced with a single blank and without leading or trailing whitespace.
+     **/
+    static std::wstring normalizeWhitespace( const std::wstring & orig );
+
+    /**
+     * Do the wrapping.
+     **/
+    void wrap();
+
+
+protected:
+
+    /**
+     * Do the wrapping if necessary.
+     **/
+    void ensureWrapped();
+
+    /**
+     * Return the next line that fits into the line width and removed it from
+     * 'unwrapped'.
+     **/
+    std::wstring nextLine( std::wstring & unwrapped );
+    
+    //
+    // Data members
+    //
+
+    std::wstring _origText;
+    std::wstring _wrappedText;
+    int          _lineWidth;
+    int          _lines;
+    bool         _dirty;
+};
+
+#endif  // NCWordWrapper_h


### PR DESCRIPTION
## Trello

https://trello.com/c/AAaxH5Cg/

**This is the libyui-ncurses part for autoWrap Label widgets.**

## Bugzilla

https://bugzilla.opensuse.org/show_bug.cgi?id=1172513

## Screenshot

![AutoWrap2-NCurses](https://user-images.githubusercontent.com/11538225/83734072-c9b58d80-a64e-11ea-8387-bb81c8d8293d.png)

### Testing the NCWordWrapper

This class contains a small `main()` to enable testing when compiled with a special `#define`:

    g++ -D WORD_WRAPPER_TESTER -o word-wrapper-tester NCWordWrapper.cc

It can then be called with a string to wrap and the line length as command line arguments:

![word-wrapper-tester-01](https://user-images.githubusercontent.com/11538225/83650418-9b856e80-a5b8-11ea-832a-a26cb8f8671f.png)

The general idea for this was taken from the _GNU gettext_ tools by Bruno Haible.
# Related PRs

- libyui: https://github.com/libyui/libyui/pull/165
- Qt UI: https://github.com/libyui/libyui-qt/pull/129
- UI interpreter: https://github.com/yast/yast-ycp-ui-bindings/pull/52

## Travis Build Failure

This depends on some new methods in libyui which are not yet available for the Travis docker image.