### PR TITLE
Document basic classes

### DIFF
--- a/src/NCPad.cc
+++ b/src/NCPad.cc
@@ -131,12 +131,12 @@ int NCPad::update()
 
         if ( ! pageing() )
         {
-	return copywin( *destwin,
-			srect.Pos.L, srect.Pos.C,
-			drect.Pos.L, drect.Pos.C,
-			maxdpos.L,   maxdpos.C,
-			false );
-    }
+	    return copywin( *destwin,
+			    srect.Pos.L, srect.Pos.C,
+			    drect.Pos.L, drect.Pos.C,
+			    maxdpos.L,   maxdpos.C,
+			    false /* are blanks transparent */);
+	}
 
         // Here: Table is pageing, so we must prepare the visible lines
         // on the Pad before we're copying them to the destwin:

--- a/src/NCPad.h
+++ b/src/NCPad.h
@@ -100,6 +100,15 @@ public:
 };
 
 
+/// A virtual window with a real viewport (which is NCursesWindow)
+/// and a scrolling mechanism.
+///
+/// In the underlying C ncurses library, a *pad* is a virtual window without a
+/// position.  Of course that is not very useful without any way to display it
+/// so there's a `prefresh` function to draw a portion of that pad into a
+/// visible "viewport" window. Our NCursesPad fork just directly forwards to
+/// `prefresh` without remembering the window. Upstream NCursesPad does know a
+/// viewport window and so does NCPad (*destwin*).
 class NCPad : public NCursesPad, public NCScrollHint
 {
 private:
@@ -123,13 +132,14 @@ protected:
 
     const NCWidget & parw;
 
-    NCursesWindow * destwin;
+    NCursesWindow * destwin; ///< Where to draw us (may be nullptr, not owned)
+    ///< Destination rectangle: (Pos is always 0, 0)
     wrect drect;
-    wrect srect;
+    wrect srect;	    ///< Source rectangle: the visible part of this pad
     wpos  maxdpos;
     wpos  maxspos;
 
-    bool  dclear;
+    bool  dclear; ///< should destwin be cleared before contents is copied there
     bool  dirty;
 
     /** The (virtual) height of the Pad (even if truncated). */
@@ -140,8 +150,10 @@ protected:
 
     virtual int dirtyPad() { dirty = false; return setpos( CurPos() ); }
 
+    /// Set the visible position to *newpos* (but clamp by *maxspos*), then \ref update.
     virtual int setpos( const wpos & newpos );
 
+    /// Adjust CurPos relatively by *offset*
     int adjpos( const wpos & offset )
     {
 	return setpos( CurPos() + offset );
@@ -162,6 +174,7 @@ protected:
 
 public:
 
+    /// @param p (used just for styling info, NOT sizing)
     NCPad( int lines, int cols, const NCWidget & p );
     virtual ~NCPad() {}
 
@@ -169,9 +182,12 @@ public:
 
     NCursesWindow * Destwin() { return destwin; }
 
+    /// @param dwin (not owned)
     virtual void Destwin( NCursesWindow * dwin );
 
     virtual void resize( wsze nsze );
+    // OMFG this little overload does something completely different than
+    // the one above
     virtual int resize( int lines, int columns ) { return NCursesWindow::resize(lines, columns );}
     virtual void wRecoded();
     virtual void setDirty() { dirty = true; }
@@ -186,11 +202,13 @@ public:
 	return setpos( newpos );
     }
 
+    /// Scroll to a line, keeping the column
     int ScrlLine( int line )
     {
 	return setpos( wpos( line, srect.Pos.C ) );
     }
 
+    /// Scroll to a column, keeping the line
     int ScrlCol( int col )
     {
 	return setpos( wpos( srect.Pos.L, col ) );

--- a/src/NCPad.h
+++ b/src/NCPad.h
@@ -31,14 +31,21 @@
 #include "NCWidget.h"
 
 
+//! Interface for scroll callbacks
 class NCSchrollCB
 {
 public:
 
     virtual ~NCSchrollCB() {}
 
+    /// @param total    virtual size
+    /// @param visible  size of the visible part
+    /// @param start    position of the visible part
     virtual void HScroll( unsigned total, unsigned visible, unsigned start ) {}
 
+    /// @param total    virtual size
+    /// @param visible  size of the visible part
+    /// @param start    position of the visible part
     virtual void VScroll( unsigned total, unsigned visible, unsigned start ) {}
 
     virtual void ScrollHead( NCursesWindow & w, unsigned ccol ) {}
@@ -46,7 +53,10 @@ public:
     virtual void AdjustPadSize( wsze & minsze ) {}
 };
 
-
+/**
+ * Forward the scroll callbacks to another object.
+ * By default it forwards to itself
+ */
 class NCScrollHint : protected NCSchrollCB
 {
 private:
@@ -83,8 +93,8 @@ protected:
 
 public:
 
-    // set redirect
-    void SendSchrollCB( NCSchrollCB * to ) { redirect = ( to ? to : this ); }
+    //! Set the receiver of callbacks to *dest*
+    void SendSchrollCB( NCSchrollCB * dest ) { redirect = ( dest ? dest : this ); }
 
     virtual void SendHead() {}
 };

--- a/src/NCPadWidget.cc
+++ b/src/NCPadWidget.cc
@@ -26,7 +26,25 @@
 #include <yui/YUILog.h>
 #include "NCPadWidget.h"
 
-
+/**
+ * Scrollbar indicator.
+ *
+ * It's a dumb indicator: it does not react to keyboard events (class FIXME
+ * does it instead)
+ *
+ * Appearance details:
+ *
+ * Suppose we have a horizontal scrollbar 10 cells wide: ~~===~~~~~
+ * The visible part of the scrolled contents is indicated by the BAR,
+ * here 3 cells wide. (The bar is also known as "slider", "puck", "elevator")
+ *
+ * Unlike in GUIs we have no arrows at the ends of the scrollbar because we
+ * can't read the mouse clicks anyway.
+ *
+ * If the scrollbar gets shrunk to size 1 or 2, it is drawn with arrows
+ * meaning there is something in the pointed direction.
+ *
+ */
 class NCScrollbar
 {
 public:
@@ -35,23 +53,24 @@ public:
 
 private:
 
-    chtype ch_forward;
-    chtype ch_backward;
-    chtype ch_barbeg;
-    chtype ch_barend;
-    chtype ch_barone;
+    chtype ch_forward;    //!< draw an arrow pointing down/right
+    chtype ch_backward;   //!< draw an arrow pointing up/left
+    chtype ch_barbeg;     //!< draw the top/left end of the bar (elevator)
+    chtype ch_barend;     //!< draw the bottom/right end of the bar (elavator)
+    chtype ch_barone; //!< draw a bar (elevator) that has the smallest visible length of 1
 
-    const NCWidget & parw;
-    NCursesWindow *  win;
-    orientation      type;
-    unsigned	     len;
+    const NCWidget & parw;      //!< parent widget
+    NCursesWindow *  win;       //!< where this indicator draws itself
+    orientation      type;      //!< horizontal or vertical
+    unsigned	     len;       //!< the length of this indicator in cells
 
-    unsigned total;
-    unsigned visible;
-    unsigned at;
+    unsigned total;             //!< 0 to total is the virtual size
+    unsigned visible;           //!< size of the visible part
+    unsigned at;                //!< position of the visible part
 
 private:
 
+    // Clamp *visible* and *at* so that visible <= visible + at <= total
     void adjust()
     {
 	if ( visible > total )
@@ -67,6 +86,7 @@ private:
 	}
     }
 
+    // line starting at *p*, length *l*
     void draw_line( unsigned p, unsigned l, chtype ch = 0 )
     {
 	if ( !l )
@@ -205,6 +225,11 @@ private:
 
 public:
 
+    /// @param parwid parent widget
+    /// @param par window of parent widget
+    /// @param p position relative to parent window
+    /// @param l length of self (width if horizontal, height if vertical)
+    /// @param orient horizontal or vertical
     NCScrollbar( const NCWidget & parwid, NCursesWindow & par, wpos p, unsigned l, orientation orient )
 	    : ch_forward( orient == HORZ ? ACS_RARROW : ACS_DARROW )
 	    , ch_backward( orient == HORZ ? ACS_LARROW : ACS_UARROW )
@@ -242,6 +267,12 @@ public:
 
 public:
 
+    /// Set the indicator. The arguments use the same units,
+    /// independent of the indicator's screen size.
+    ///
+    /// @param tot   total virtual size
+    /// @param vis   size of the visible part
+    /// @param start position of the visible part
     void set( unsigned tot, unsigned vis, unsigned start )
     {
 	total	= tot;

--- a/src/NCPadWidget.h
+++ b/src/NCPadWidget.h
@@ -47,13 +47,13 @@ private:
 
 
     NClabel	    label;
-    NCursesWindow * padwin;
-    NCScrollbar *   hsb;
-    NCScrollbar *   vsb;
+    NCursesWindow * padwin;    ///< (owned IFF different from NCWidget::*win*)
+    NCScrollbar *   hsb;               ///< (owned)
+    NCScrollbar *   vsb;               ///< (owned)
 
     wsze  minPadSze;
     bool  multidraw;
-    NCPad * pad;
+    NCPad * pad;                ///< (owned)
 
 protected:
 

--- a/src/NCPadWidget.h
+++ b/src/NCPadWidget.h
@@ -33,7 +33,9 @@
 class NCPadWidget;
 class NCScrollbar;
 
-
+/**
+ * Base class for widgets with scrollable contents
+ */
 class NCPadWidget : public NCWidget, protected NCSchrollCB
 {
 private:

--- a/src/NCWidget.h
+++ b/src/NCWidget.h
@@ -100,7 +100,7 @@ public:
 
 protected:
 
-    NCursesWindow * win;
+    NCursesWindow * win;        ///< (owned)
     wsze	    defsze;
     wrect	    framedim;
     wrect	    inparent;

--- a/src/NCstring.cc
+++ b/src/NCstring.cc
@@ -37,10 +37,6 @@
 std::string	NCstring::termEncoding( "UTF-8" );
 
 
-
-
-
-
 NCstring:: NCstring()
 	: hotk( 0 )
 	, hotp( std::wstring::npos )
@@ -48,7 +44,6 @@ NCstring:: NCstring()
 
 {
 }
-
 
 
 NCstring::NCstring( const NCstring & nstr )
@@ -59,14 +54,12 @@ NCstring::NCstring( const NCstring & nstr )
 }
 
 
-
 NCstring::NCstring( const std::wstring & widestr )
 	: hotk( 0 )
 	, hotp( std::wstring::npos )
 	, wstr( widestr )
 {
 }
-
 
 
 NCstring::NCstring( const std::string & str )
@@ -82,7 +75,6 @@ NCstring::NCstring( const std::string & str )
 }
 
 
-
 NCstring::NCstring( const char * cstr )
 	: hotk( 0 )
 	, hotp( std::wstring::npos )
@@ -96,12 +88,10 @@ NCstring::NCstring( const char * cstr )
 }
 
 
-
 std::ostream & operator<<( std::ostream & str, const NCstring & obj )
 {
     return str <<  obj.Str() ;
 }
-
 
 
 NCstring & NCstring::operator=( const NCstring & nstr )
@@ -115,7 +105,6 @@ NCstring & NCstring::operator=( const NCstring & nstr )
 
     return *this;
 }
-
 
 
 NCstring & NCstring::operator+=( const NCstring & nstr )
@@ -307,7 +296,6 @@ bool NCstring::RecodeToWchar( const std::string& in, const std::string &from_enc
 
     return true;
 }
-
 
 
 std::string NCstring::Str() const

--- a/src/NCstring.h
+++ b/src/NCstring.h
@@ -29,18 +29,28 @@
 #include <string>
 
 
+/// A string with an optional hot key.
+///
+/// The current implementation stores a std::wstring.
 class NCstring
 {
 private:
 
     friend std::ostream & operator<<( std::ostream & str, const NCstring & obj );
 
+    mutable wchar_t hotk;                 ///< hotkey
+    /// Position of hotkey in columns(!). *npos* means unset.
+    ///
+    /// CJK characters take 2 columns. So in the Chinese "Yes" button,
+    /// L"是(Y)", *hotp* for L'Y' is 3 even though
+    ///its wchar_t offset is 2 (and its UTF-8 offset is 4).
+    mutable std::wstring::size_type hotp;
+    mutable std::wstring   wstr;	  ///< the actual string
 
-    mutable wchar_t hotk;		// hotkey
-    mutable std::wstring::size_type hotp;	// position of hotkey
-    mutable std::wstring   wstr;
-
-    static std::string	termEncoding;	// the encoding of the terminal
+    /// The encoding of the terminal; the value is ignored by this class.
+    /// WTF, really: other classes care
+    /// but this class just uses UTF-8 for non-wide characters.
+    static std::string	termEncoding;
 
 public:
 
@@ -50,12 +60,15 @@ public:
 
     NCstring( const std::wstring & wstr );
 
+    /// Init from a UTF-8 string.
     NCstring( const std::string & str );
 
+    /// Init from a UTF-8 string.
     NCstring( const char * cstr );
 
     ~NCstring() {}
 
+    /// Get a UTF-8 string.
     std::string Str() const;
 
 public:
@@ -85,6 +98,7 @@ public:
 
     static bool setTerminalEncoding( const std::string & encoding = "" );
 
+    /// (mutates the const object)
     void getHotkey() const;
 };
 

--- a/src/NCtext.h
+++ b/src/NCtext.h
@@ -33,7 +33,7 @@
 
 class NCursesWindow;
 
-
+/// Multi-line string
 class NCtext
 {
 
@@ -77,7 +77,7 @@ public:
 };
 
 
-
+/// Multi-line string, with optional hotkey, drawable
 class NClabel : protected NCtext
 {
 

--- a/src/NCtypes.h
+++ b/src/NCtypes.h
@@ -27,8 +27,10 @@
 
 #include <iosfwd>
 
+/// A sad little namespace
 namespace NC
 {
+    /// Alignment aka justification: top/bottom, left/right, center.
     enum ADJUST
     {
 	CENTER = 0x00,

--- a/src/position.h
+++ b/src/position.h
@@ -27,7 +27,7 @@
 
 #include <iosfwd>
 
-
+//! A pair of 2 numbers, the base class for wpos and wsze.
 class wpair
 {
 
@@ -40,6 +40,7 @@ protected:
 
 public:
 
+    /// Set BOTH members to *v*
     wpair( int v = 0 )	      { A = B = v; }
 
     wpair( int a, int b ) { A = a; B = b; }
@@ -82,7 +83,7 @@ public:
 
     bool operator<=( const wpair & Rhs ) const { return A <= Rhs.A && B <= Rhs.B; }
 
-
+    /// a copy of *this* clamped between *Min* and *Max*
     wpair between( const wpair & Min, const wpair & Max ) const
 	{
 	    return min( max( *this, Min ), Max );
@@ -104,8 +105,7 @@ public:
 
 
 
-// screen position in (line,col)
-
+//! Screen position pair in the order line, column: (L, C)
 class wpos : public wpair
 {
 
@@ -149,8 +149,7 @@ extern std::ostream & operator<<( std::ostream & str, const wpos & obj );
 
 
 
-// screen dimension in (height,width)
-
+//! Screen dimension (screen size) in the order height, width: (H, W)
 class wsze : public wpair
 {
 
@@ -190,10 +189,7 @@ public:
 
 extern std::ostream & operator<<( std::ostream & str, const wsze & obj );
 
-
-
-// rectangle {wpos,wsze}
-
+//! A rectangle is defined by its position and size: wpos Pos, wsze Sze.
 class wrect
 {
 


### PR DESCRIPTION
This is a companion to #100, separating just the things I learned along the way into documentation comments.

- NCPad and its scrolling buddies
- ~Table related classes~ :arrow_right: moved to live with the  #100 fix
- strings: `NCstring` `NCtext` `NClabel`
- dimensions: `wpair` `wpos` `wsze` `wrect`
- `tnode` (a tree of pointers, used for widget nesting)

Notably, the name `NCTableCol` seems to represent a "column" but in fact it
represents a single cell. It is a candidate for renaming but I did not want to
go that far at this stage.

Preview: <https://libyui-ncurses.surge.sh/annotated.html>

Compare with <https://doc.opensuse.org/projects/libyui/HEAD/> for the base library only, 9 years old :facepalm: 