### PR TITLE
Refresh widgets after shortcuts changes

### DIFF
--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -500,6 +500,23 @@ NCItemSelectorBase::wHandleInput( wint_t key )
             myPad()->ScrlUp();
             break;
 
+	case KEY_HOTKEY:
+
+	    changedItem = curItem;
+	    curItem = findItemWithHotkey( _hotKey );
+
+	    if ( curItem )
+	    {
+		setCurrentItem( curItem );
+
+		if ( ! changedItem )
+		    changedItem = curItem;
+
+		cycleCurrentItemStatus();
+	    }
+
+	    break;
+
         default:
             handleInput( key ); // Call base class input handler
             break;
@@ -531,6 +548,17 @@ void NCItemSelectorBase::shortcutChanged()
     // know which one. So let's simply redraw the widget again.
 
     wRedraw();
+}
+
+
+bool NCItemSelectorBase::HasHotkey( int key )
+{
+    if ( ! findItemWithHotkey( key ) )
+	return false;
+
+    _hotKey = key;
+
+    return true;
 }
 
 
@@ -622,4 +650,19 @@ void NCItemSelector::deselectAllItemsExcept( YItem * exceptItem )
     }
 
     DrawPad();
+}
+
+
+YItem* NCItemSelectorBase::findItemWithHotkey( int key ) const
+{
+    for ( YItemConstIterator it = itemsBegin(); it != itemsEnd(); it++ )
+    {
+	NClabel label = NCstring( (*it)->label() );
+	label.stripHotkey();
+
+	if ( label.hasHotkey() && tolower( label.hotkey() ) == tolower( key ) )
+	    return *it;
+    }
+
+    return nullptr;
 }

--- a/src/NCItemSelector.cc
+++ b/src/NCItemSelector.cc
@@ -234,6 +234,8 @@ void NCItemSelectorBase::addItem( YItem * item )
 	    myPad()->Append( cells );
 	}
 
+	myPad()->stripHotkeys();
+
 	DrawPad();
     }
 }
@@ -521,6 +523,16 @@ void NCItemSelectorBase::activateItem( YItem * item )
         YNCursesUI::ui()->sendEvent( event );
     }
 }
+
+
+void NCItemSelectorBase::shortcutChanged()
+{
+    // Any of the items might have its keyboard shortcut changed, but we don't
+    // know which one. So let's simply redraw the widget again.
+
+    wRedraw();
+}
+
 
 // ----------------------------------------------------------------------
 

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -173,6 +173,12 @@ public:
      **/
     virtual void shortcutChanged();
 
+    /**
+     * Whether any item has the given hot-key .
+     * Reimplemented from NCWidget.
+     **/
+    virtual bool HasHotkey( int key ) ;
+
 protected:
 
     /**
@@ -271,6 +277,7 @@ private:
     NCItemSelectorBase & operator=( const NCItemSelectorBase & );
     NCItemSelectorBase( const NCItemSelectorBase & );
 
+    YItem* findItemWithHotkey( int key ) const;
 
 protected:
 
@@ -278,7 +285,9 @@ protected:
 
     wsze _prefSize;
     bool _prefSizeDirty;
-    int	 _selectorWidth;
+    int _selectorWidth;
+    int _hotKey;
+
 
 };	// class NCItemSelectorBase
 

--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -166,6 +166,13 @@ public:
      **/
     virtual void activateItem( YItem * item );
 
+    /**
+     * Notification that some shortcut was changed.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void shortcutChanged();
+
 protected:
 
     /**

--- a/src/NCMenuBar.cc
+++ b/src/NCMenuBar.cc
@@ -298,6 +298,16 @@ NCMenuBar::wHandleHotkey( wint_t key )
 }
 
 
+void
+NCMenuBar::shortcutChanged()
+{
+    // Any of the items might have its keyboard shortcut changed, but we don't
+    // know which one. So let's simply redraw the widget again.
+
+    wRedraw();
+}
+
+
 NCursesEvent
 NCMenuBar::handlePostMenu( const NCursesEvent & event )
 {

--- a/src/NCMenuBar.h
+++ b/src/NCMenuBar.h
@@ -115,6 +115,13 @@ public:
      **/
     virtual bool HasHotkey( int key ) ;
 
+    /**
+     * Notification that some shortcut was changed.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void shortcutChanged();
+
 protected:
 
     /**


### PR DESCRIPTION
Improvements to avoid conflicts with the shortcuts of the *NCItemSelector* and *NCMenuBar* widgets,  see https://github.com/libyui/libyui/pull/170. It also adds the missing support to manage shortcuts in *NCItemSelector*.

* PBI: https://trello.com/c/fCUBIGGg/2023-3-tw-p3-1175142-yast-menu-bar-toplevel-shortcut-conflicts
* https://bugzilla.suse.com/show_bug.cgi?id=1175142

### Notes

* Due to some strange bug, the hotkeys are not highlighted in the *NCItemSelector* widget. We are trying to find the source of the problem.
* The changes in this PR imply to bump the so version, but this will be done when the *sprint-108* branch includes all the changes to do during this sprint.