### PR TITLE
Improve menubar shortcuts

### DIFF
--- a/src/NCMenuBar.cc
+++ b/src/NCMenuBar.cc
@@ -221,7 +221,13 @@ NCMenuBar::wHandleInput( wint_t key )
 	    wRedraw();
 	    break;
 
+	case KEY_BACKSPACE:
+	    wRedraw();
+	    break;
+
 	case KEY_DOWN:
+	case KEY_SPACE:
+	case KEY_RETURN:
 	    event = postMenu();
 	    break;
 
@@ -329,6 +335,10 @@ NCMenuBar::handlePostMenu( const NCursesEvent & event )
 	{
 	    wHandleInput( KEY_RIGHT );
 	    newEvent = wHandleInput( KEY_DOWN );
+	}
+	else if ( event.keySymbol == "BackSpace" )
+	{
+	    newEvent = wHandleInput( KEY_BACKSPACE );
 	}
     }
 

--- a/src/NCMenuBar.cc
+++ b/src/NCMenuBar.cc
@@ -340,6 +340,10 @@ NCMenuBar::handlePostMenu( const NCursesEvent & event )
 	{
 	    newEvent = wHandleInput( KEY_BACKSPACE );
 	}
+	else if ( event.keySymbol == "Hotkey" )
+	{
+	    newEvent = wHandleHotkey( event.detail );
+	}
     }
 
     return newEvent;

--- a/src/NCPopupMenu.cc
+++ b/src/NCPopupMenu.cc
@@ -134,8 +134,16 @@ NCursesEvent NCPopupMenu::wHandleInput( wint_t ch )
 	    event.keySymbol = "BackSpace";
 	    break;
 
-	default:
+	case KEY_RETURN:
 	    event = NCPopup::wHandleInput( ch );
+	    break;
+
+	default:
+	    event = wHandleHotkey( ch );
+
+	    if ( event == NCursesEvent::none )
+		event = NCPopup::wHandleInput( ch );
+
 	    break;
     }
 

--- a/src/NCPopupMenu.cc
+++ b/src/NCPopupMenu.cc
@@ -134,6 +134,7 @@ NCursesEvent NCPopupMenu::wHandleInput( wint_t ch )
 	    event.keySymbol = "BackSpace";
 	    break;
 
+	case KEY_SPACE:
 	case KEY_RETURN:
 	    event = NCPopup::wHandleInput( ch );
 	    break;
@@ -145,6 +146,21 @@ NCursesEvent NCPopupMenu::wHandleInput( wint_t ch )
 		event = NCPopup::wHandleInput( ch );
 
 	    break;
+    }
+
+    return event;
+}
+
+
+NCursesEvent NCPopupMenu::wHandleHotkey( wint_t key )
+{
+    NCursesEvent event = NCPopupTable::wHandleHotkey( key );
+
+    if ( event == NCursesEvent::none )
+    {
+	event = NCursesEvent::key;
+	event.keySymbol = "Hotkey";
+	event.detail = key;
     }
 
     return event;

--- a/src/NCPopupMenu.cc
+++ b/src/NCPopupMenu.cc
@@ -129,6 +129,11 @@ NCursesEvent NCPopupMenu::wHandleInput( wint_t ch )
 	    selectPreviousItem();
 	    break;
 
+	case KEY_BACKSPACE:
+	    event = NCursesEvent::key;
+	    event.keySymbol = "BackSpace";
+	    break;
+
 	default:
 	    event = NCPopup::wHandleInput( ch );
 	    break;

--- a/src/NCPopupMenu.h
+++ b/src/NCPopupMenu.h
@@ -58,6 +58,8 @@ private:
 protected:
 
     virtual NCursesEvent wHandleInput( wint_t ch );
+    virtual NCursesEvent wHandleHotkey( wint_t key );
+
     virtual bool postAgain();
 
 public:


### PR DESCRIPTION
## Problem

The new *NCMenuBar* widget is still missing some key handling that is present in other menu systems:

* *RETURN*, *SPACE*: should open the selected top level menu.
* Select an option from a menu by using hotkeys directly (without *ALT*).
* Shortcuts allow to jump to another top level menu.

 ### Solution

The missing key handling is now supported. Moreover, *BACKSPACE* can now be used to close the currently open top level menu. Note that *ESCAPE* also does it, but it has some delay because the dialog is waiting for a second key.

Note: When a top level menu is open, *ALT + hotkey* allows jumping to another top level menu. But that shortcut might conflict with the hotkey of some option from the currently open menu. In that case, the option of the currently open menu is selected instead of jumping to another menu.
