### PR TITLE
Fix hotkey rendering for NCItemSelector

### DIFF
--- a/src/NCItemSelector.h
+++ b/src/NCItemSelector.h
@@ -182,6 +182,11 @@ public:
 protected:
 
     /**
+     * Create a widget for the given item.
+     **/
+    void createItemWidget( YItem * item );
+
+    /**
      * Create a tag cell for an item. This is the cell with the "[x]" or "(x)"
      * selector. It also stores the item pointer so the item can later be
      * referenced by this tag.

--- a/src/NCTableItem.h
+++ b/src/NCTableItem.h
@@ -73,7 +73,7 @@ private:
 
     YTableItem *yitem;          ///< not owned
 
-    
+
 protected:
     // this should have been an argument for DrawItems
     mutable STATE vstate;

--- a/src/NCTablePad.h
+++ b/src/NCTablePad.h
@@ -226,6 +226,11 @@ public:
 	dirtyHead = false;
     }
 
+    void AssertMinCols( unsigned num )
+    {
+	ItemStyle.AssertMinCols( num );
+    }
+
     void SetSepChar( const chtype colSepchar )
     {
 	ItemStyle.SetSepChar( colSepchar );


### PR DESCRIPTION
### Problem

Multiple shortcuts are now supported for widgets like *NCMenuBar* and *NCItemSelector*, see https://github.com/libyui/libyui/pull/170 and https://github.com/libyui/libyui-ncurses/pull/101. But the hotkeys were not correctly highlighted in the *NCItemSelector* widget

* Part of PBI: https://trello.com/c/fCUBIGGg/2023-3-tw-p3-1175142-yast-menu-bar-toplevel-shortcut-conflicts
* Related to: https://bugzilla.suse.com/show_bug.cgi?id=1175142

### Soluction

*NCItemSelectorBase* was adapted to render hotkeys correctly.

![Screenshot from 2020-09-10 16-11-54](https://user-images.githubusercontent.com/1112304/92751909-57a4c100-f380-11ea-8825-40a26ad3e87c.png)

![Screenshot from 2020-09-10 16-11-26](https://user-images.githubusercontent.com/1112304/92751922-5a9fb180-f380-11ea-9fde-f1463dfc9a63.png)
