### PR TITLE
Allow to show or hide menu items

### DIFF
--- a/src/NCMenuBar.cc
+++ b/src/NCMenuBar.cc
@@ -111,6 +111,9 @@ NCMenuBar::rebuildMenuTree()
 	if ( ! item->isMenu() )
 	    YUI_THROW( YUIException( "NCMenuBar: Only menus allowed on toplevel. ") );
 
+	if ( ! item->isVisible() )
+	    continue;
+
 	Menu * menu = new Menu();
 	menu->item = item;
 	menu->position = wpos( 0, width );
@@ -184,6 +187,15 @@ void
 NCMenuBar::setItemEnabled( YMenuItem * item, bool enabled )
 {
     YMenuWidget::setItemEnabled( item, enabled );
+    rebuildMenuTree();
+    wRedraw();
+}
+
+
+void
+NCMenuBar::setItemVisible( YMenuItem * item, bool visible )
+{
+    YMenuWidget::setItemVisible( item, visible );
     rebuildMenuTree();
     wRedraw();
 }

--- a/src/NCMenuBar.h
+++ b/src/NCMenuBar.h
@@ -58,6 +58,13 @@ public:
     virtual void setItemEnabled( YMenuItem * item, bool enabled );
 
     /**
+     * show or hide an item.
+     *
+     * Reimplemented from YMenuWidget.
+     **/
+    virtual void setItemVisible( YMenuItem * item, bool visible );
+
+    /**
      * Support for the Rest API for UI testing:
      *
      * Activate the item selected in the tree.

--- a/src/NCPopupMenu.cc
+++ b/src/NCPopupMenu.cc
@@ -59,6 +59,9 @@ NCPopupMenu::NCPopupMenu( const wpos & at, YItemIterator begin, YItemIterator en
 	YMenuItem * menuItem = dynamic_cast<YMenuItem *>( *it );
 	YUI_CHECK_PTR( menuItem );
 
+	if ( ! menuItem->isVisible() )
+	    continue;
+
 	row[0] = menuItem->label();
 	row[1] = menuItem->hasChildren() ? "..." : "";
 


### PR DESCRIPTION
Note: This PR is going to be merged into *sprint-108* branch instead of master. There are some WIP features (i.e., nesting tables) and they all will be merged together into master to bump so versions only once.

See https://github.com/libyui/libyui/pull/172.

#### Changes

The *sprint-108* branch is accumulating several new features. The plan is to merge them all into master and bump the so versions only once. At that time, we will provide an entry in the *changes* file. Here is a proposal for that changes entry:

~~~
* Resolve hotkeys conflicts for widgets with multiple hotkeys.
* Activate the menu hotkeys without using the ALT key.
* Close a menu by using BACKSPACE.
* Allow to use hotkeys to jump between menus. 
* Related to bsc#1175489
* Allow to show/hide menus and menu items (related to
  manatools/libyui-mga#1).
* Allow nested items in tables (bsc#1176402).
~~~