### PR TITLE
Fixed changelog from 2008 after a check bot complaint

### DIFF
--- a/package/libyui-ncurses.changes
+++ b/package/libyui-ncurses.changes
@@ -664,7 +664,7 @@ Wed May 14 10:22:58 CEST 2008 - gs@suse.de
 - V 2.16.26  
 
 -------------------------------------------------------------------
-Tue Apr 15:39:14 CEST 2008 - tgoettlicher@suse.de
+Tue Apr 15 15:39:14 CEST 2008 - tgoettlicher@suse.de
 
 - fixed keyboard shortcuts in popup menu (bnc #377098)
 - V 2.16.25


### PR DESCRIPTION
The last PR #115 couldn't be submitted since yet another one of those OBS scripts kept sabotaging our work with newly introduced checks: It complained about a change log entry from the year 2008 (!) in a very recent version of this check script.

From 2008 until 2025 nobody cared, yet now we can't submit a new version anymore because somebody "improved" this script.